### PR TITLE
Add option to prevent tokens from giving TextPrompts or chatlogs

### DIFF
--- a/CollectTokenHandler.cs
+++ b/CollectTokenHandler.cs
@@ -202,7 +202,7 @@ namespace RainWorldRandomizer
             orig(self, player);
 
             // Prevent TextPrompt from being issued.
-            if (Plugin.disableTokenCollection.Value) self.anythingUnlocked = false;
+            if (Plugin.disableTokenText.Value) self.anythingUnlocked = false;
 
             string tokenString = (self.placedObj.data as CollectToken.CollectTokenData).tokenString;
 
@@ -527,7 +527,7 @@ namespace RainWorldRandomizer
         }
 
         /// <summary>
-        /// If <see cref="Plugin.disableTokenCollection"/> is enabled, prevent chatlogs from happening.
+        /// If <see cref="Plugin.disableTokenText"/> is enabled, prevent chatlogs from happening.
         /// </summary>
         private void Player_ProcessChatLog(ILContext il)
         {
@@ -535,17 +535,17 @@ namespace RainWorldRandomizer
 
             // Prevent stun and mushroom effect (branch interception at 0026).
             c.GotoNext(MoveType.After, x => x.MatchCallOrCallvirt(typeof(ExtEnum<ChatlogData.ChatlogID>).GetMethod("op_Inequality")));
-            bool PreventStun(bool prev) => prev && !Plugin.disableTokenCollection.Value;
+            bool PreventStun(bool prev) => prev && !Plugin.disableTokenText.Value;
             c.EmitDelegate<Func<bool, bool>>(PreventStun);
 
             // Prevent chatlog from being displayed (branch interception at 00b1).
             c.GotoNext(MoveType.Before, x => x.MatchLdcI4(60));  // 00aa
-            int PreventChatlog(int prev) => Plugin.disableTokenCollection.Value ? 59 : prev;
+            int PreventChatlog(int prev) => Plugin.disableTokenText.Value ? 59 : prev;
             c.EmitDelegate<Func<int, int>>(PreventChatlog);
         }
 
         /// <summary>
-        /// If <see cref="Plugin.disableTokenCollection"/> is enabled, prevent Slugcat from being stopped by touching a chatlog token.
+        /// If <see cref="Plugin.disableTokenText"/> is enabled, prevent Slugcat from being stopped by touching a chatlog token.
         /// </summary>
         private void Player_InitChatLog(ILContext il)
         {
@@ -553,7 +553,7 @@ namespace RainWorldRandomizer
 
             // Prevent the `for` loop from running (branch interception at 0038).
             c.GotoNext(MoveType.Before, x => x.MatchConvI4());  // 0037
-            int PreventStop(int prev) => Plugin.disableTokenCollection.Value ? 0 : prev;
+            int PreventStop(int prev) => Plugin.disableTokenText.Value ? 0 : prev;
             c.EmitDelegate<Func<int, int>>(PreventStop);
         }
 

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -126,9 +126,9 @@ namespace RainWorldRandomizer
                 new ConfigurableInfo("Whether DeathLinks sent in between gameplay are postponed or completely ignored", null, "",
                 new object[] { "Ignore Menu Deaths" }));
 
-            Plugin.disableTokenCollection = config.Bind<bool>("DisableTokenCollection", false,
-                new ConfigurableInfo("Disable collection of tokens, preventing pop-up text and broadcast chatlogs from appearing", null, "",
-                new object[] { "Disable token collection" }));
+            Plugin.disableTokenText = config.Bind<bool>("DisableTokenCollection", false,
+                new ConfigurableInfo("Disable pop-up text and chatlogs from appearing when collecting tokens", null, "",
+                new object[] { "Disable token text" }));
         }
 
         public override void Initialize()
@@ -383,14 +383,14 @@ namespace RainWorldRandomizer
             };
             runningY -= 35;
 
-            OpCheckBox disableTokenCollectionCheckBox = new OpCheckBox(Plugin.disableTokenCollection, new Vector2(420f, runningY))
+            OpCheckBox disableTokenTextCheckBox = new OpCheckBox(Plugin.disableTokenText, new Vector2(420f, runningY))
             {
-                description = Translate(Plugin.disableTokenCollection.info.description)
+                description = Translate(Plugin.disableTokenText.info.description)
             };
-            OpLabel disableTokenCollectionLabel = new OpLabel(460f, runningY, Translate(Plugin.disableTokenCollection.info.Tags[0] as string))
+            OpLabel disableTokenTextLabel = new OpLabel(460f, runningY, Translate(Plugin.disableTokenText.info.Tags[0] as string))
             {
-                bumpBehav = disableTokenCollectionCheckBox.bumpBehav,
-                description = disableTokenCollectionCheckBox.description
+                bumpBehav = disableTokenTextCheckBox.bumpBehav,
+                description = disableTokenTextCheckBox.description
             };
             runningY -= 35;
 
@@ -492,8 +492,8 @@ namespace RainWorldRandomizer
                 noKarmaLossLabel,
                 ignoreMenuDeathsCheckBox,
                 ignoreMenuDeathsLabel,
-                disableTokenCollectionCheckBox,
-                disableTokenCollectionLabel,
+                disableTokenTextCheckBox,
+                disableTokenTextLabel,
             });
         }
 

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -125,6 +125,10 @@ namespace RainWorldRandomizer
             Plugin.archipelagoIgnoreMenuDL = config.Bind<bool>("ArchipelagoIgnoreMenuDL", true,
                 new ConfigurableInfo("Whether DeathLinks sent in between gameplay are postponed or completely ignored", null, "",
                 new object[] { "Ignore Menu Deaths" }));
+
+            Plugin.disableTokenCollection = config.Bind<bool>("DisableTokenCollection", false,
+                new ConfigurableInfo("Disable collection of tokens, preventing pop-up text and broadcast chatlogs from appearing", null, "",
+                new object[] { "Disable token collection" }));
         }
 
         public override void Initialize()
@@ -379,6 +383,17 @@ namespace RainWorldRandomizer
             };
             runningY -= 35;
 
+            OpCheckBox disableTokenCollectionCheckBox = new OpCheckBox(Plugin.disableTokenCollection, new Vector2(420f, runningY))
+            {
+                description = Translate(Plugin.disableTokenCollection.info.description)
+            };
+            OpLabel disableTokenCollectionLabel = new OpLabel(460f, runningY, Translate(Plugin.disableTokenCollection.info.Tags[0] as string))
+            {
+                bumpBehav = disableTokenCollectionCheckBox.bumpBehav,
+                description = disableTokenCollectionCheckBox.description
+            };
+            runningY -= 35;
+
             // ----- Update / Button Logic -----
 
             void APCheckedChange()
@@ -477,6 +492,8 @@ namespace RainWorldRandomizer
                 noKarmaLossLabel,
                 ignoreMenuDeathsCheckBox,
                 ignoreMenuDeathsLabel,
+                disableTokenCollectionCheckBox,
+                disableTokenCollectionLabel,
             });
         }
 

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -72,6 +72,10 @@ namespace RainWorldRandomizer
                 "Gates will have their karma requirements decreased to match", null, "", 
                     new object[] { "Start with low karma" }));
 
+            Plugin.disableTokenText = config.Bind<bool>("DisableTokenText", false,
+                new ConfigurableInfo("Prevent pop-up text and chatlogs from appearing when collecting tokens", null, "",
+                new object[] { "Disable token text" }));
+
             // ----- MSC -----
             Plugin.allowMetroForOthers = config.Bind<bool>("allowMetroForOthers", false,
                 new ConfigurableInfo("Allows access to Metropolis as non-Artificer slugcats (Where applicable)", null, "", 
@@ -125,10 +129,6 @@ namespace RainWorldRandomizer
             Plugin.archipelagoIgnoreMenuDL = config.Bind<bool>("ArchipelagoIgnoreMenuDL", true,
                 new ConfigurableInfo("Whether DeathLinks sent in between gameplay are postponed or completely ignored", null, "",
                 new object[] { "Ignore Menu Deaths" }));
-
-            Plugin.disableTokenText = config.Bind<bool>("DisableTokenCollection", false,
-                new ConfigurableInfo("Disable pop-up text and chatlogs from appearing when collecting tokens", null, "",
-                new object[] { "Disable token text" }));
         }
 
         public override void Initialize()
@@ -383,17 +383,6 @@ namespace RainWorldRandomizer
             };
             runningY -= 35;
 
-            OpCheckBox disableTokenTextCheckBox = new OpCheckBox(Plugin.disableTokenText, new Vector2(420f, runningY))
-            {
-                description = Translate(Plugin.disableTokenText.info.description)
-            };
-            OpLabel disableTokenTextLabel = new OpLabel(460f, runningY, Translate(Plugin.disableTokenText.info.Tags[0] as string))
-            {
-                bumpBehav = disableTokenTextCheckBox.bumpBehav,
-                description = disableTokenTextCheckBox.description
-            };
-            runningY -= 35;
-
             // ----- Update / Button Logic -----
 
             void APCheckedChange()
@@ -492,8 +481,6 @@ namespace RainWorldRandomizer
                 noKarmaLossLabel,
                 ignoreMenuDeathsCheckBox,
                 ignoreMenuDeathsLabel,
-                disableTokenTextCheckBox,
-                disableTokenTextLabel,
             });
         }
 
@@ -514,6 +501,7 @@ namespace RainWorldRandomizer
                 Plugin.giveItemUnlocks,
                 Plugin.itemShelterDelivery,
                 Plugin.givePassageUnlocks,
+                Plugin.disableTokenText,
             };
 
             boolConfigOrderMSC = new Configurable<bool>[]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -110,6 +110,7 @@ namespace RainWorldRandomizer
         public static Configurable<bool> disableNotificationQueue;
         public static Configurable<bool> archipelagoPreventDLKarmaLoss;
         public static Configurable<bool> archipelagoIgnoreMenuDL;
+        public static Configurable<bool> disableTokenCollection;
         #endregion
 
         //public static bool isRandomizerActive = false; // -- Move to manager base

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -110,7 +110,7 @@ namespace RainWorldRandomizer
         public static Configurable<bool> disableNotificationQueue;
         public static Configurable<bool> archipelagoPreventDLKarmaLoss;
         public static Configurable<bool> archipelagoIgnoreMenuDL;
-        public static Configurable<bool> disableTokenCollection;
+        public static Configurable<bool> disableTokenText;
         #endregion
 
         //public static bool isRandomizerActive = false; // -- Move to manager base


### PR DESCRIPTION
Adds a Remix option to prevent regular tokens from giving `TextPrompt`s (which overtake the HUD) and broadcasts/devtokens from giving chatlogs to improve the flow of the randomizer.