### PR TITLE
Fix pearl location name calculation

### DIFF
--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -333,7 +333,8 @@ namespace RainWorldRandomizer
                                 // More costly lookup to find where this pearl comes from
                                 foreach (var region in self.rainWorld.regionDataPearls)
                                 {
-                                    if (region.Value.Contains(pearl.AbstractPearl.dataPearlType))
+                                    if (region.Value.Contains(pearl.AbstractPearl.dataPearlType)
+                                        && Plugin.RandoManager.LocationExists(locName + $"-{region.Key.ToUpperInvariant()}"))
                                     {
                                         locName += $"-{region.Key.ToUpperInvariant()}";
                                         break;

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -324,7 +324,7 @@ namespace RainWorldRandomizer
                         if (Plugin.RandoManager is ManagerArchipelago)
                         {
                             // Check if this pearl matching the current region is valid
-                            if (Plugin.RandoManager.LocationExists(locName + currentRoom.abstractRoom.name.Substring(0, 2)))
+                            if (Plugin.RandoManager.LocationExists(locName + $"-{currentRoom.abstractRoom.name.Substring(0, 2)}"))
                             {
                                 locName += $"-{currentRoom.abstractRoom.name.Substring(0, 2)}";
                             }


### PR DESCRIPTION
Untested.

The current pearl location name calculation (at the edited line) *never* returns a valid location name because it omits the dash before the region name.  As a consequence, it *always* runs the `regionDataPearls` lookup, which won't (reliably?) find pearls in conditional regions such as LM, UG, RM, and CL.  Any moved pearls, like `Pearl-MS-GW` / `Pearl-MS-MS`, could suffer a similar fate.

This is a band-aid fix and reveals a broader problem with the way the APWorld defines its locations.  We should maybe consider having just a `Pearl-SL_chimney` location which just gets moved between regions, though this requires a few decent changes to how it defines locations.