### PR TITLE
Add "Return Home" button

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -1,5 +1,7 @@
-﻿using MoreSlugcats;
+﻿using MonoMod.Utils;
+using MoreSlugcats;
 using System.Collections.Generic;
+using Watcher;
 
 namespace RainWorldRandomizer
 {
@@ -132,5 +134,34 @@ namespace RainWorldRandomizer
             }}
         };
 
+        public static readonly Dictionary<SlugcatStats.Name, string> SlugcatDefaultStartingDen = new Dictionary<SlugcatStats.Name, string>()
+        {
+            { SlugcatStats.Name.White, "SU_S01" },
+            { SlugcatStats.Name.Yellow, "SU_S01" },
+            { SlugcatStats.Name.Red, "LF_S02" },
+        };
+
+        public static void InitializeConstants()
+        {
+            // Add constant entries that require MSC
+            if (ModManager.MSC)
+            {
+                SlugcatDefaultStartingDen.AddRange(new Dictionary<SlugcatStats.Name, string>()
+                {
+                    { MoreSlugcatsEnums.SlugcatStatsName.Gourmand, "SH_S02" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Artificer, "GW_S09" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Rivulet, "DS_S02l" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Spear, "SU_S05" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Saint, "SI_S04" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel, "SH_S09" },
+                });
+            }
+
+            // Add Constant entries that require Watcher
+            if (ModManager.Watcher)
+            {
+                SlugcatDefaultStartingDen.Add(WatcherEnums.SlugcatStatsName.Watcher, "HI_WS01");
+            }
+        }
     }
 }

--- a/Hooks/SleepScreenHooks.cs
+++ b/Hooks/SleepScreenHooks.cs
@@ -24,7 +24,7 @@ namespace RainWorldRandomizer
             try
             {
                 IL.MoreSlugcats.CollectiblesTracker.ctor += CreateCollectiblesTrackerIL;
-                IL.Menu.EndgameTokens.ctor += EngameTokensCtorIL;
+                IL.Menu.EndgameTokens.ctor += EndgameTokensCtorIL;
                 IL.Menu.SleepAndDeathScreen.AddPassageButton += AddPassageButtonIL;
                 IL.Menu.SleepAndDeathScreen.GetDataFromGame += SleepAndDeathScreenGetDataFromGameIL;
             }
@@ -43,7 +43,7 @@ namespace RainWorldRandomizer
             On.Menu.KarmaLadder.ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool -= OnKarmaLadderCtor;
 
             IL.MoreSlugcats.CollectiblesTracker.ctor -= CreateCollectiblesTrackerIL;
-            IL.Menu.EndgameTokens.ctor -= EngameTokensCtorIL;
+            IL.Menu.EndgameTokens.ctor -= EndgameTokensCtorIL;
             IL.Menu.SleepAndDeathScreen.AddPassageButton -= AddPassageButtonIL;
             IL.Menu.SleepAndDeathScreen.GetDataFromGame -= SleepAndDeathScreenGetDataFromGameIL;
         }
@@ -329,7 +329,7 @@ namespace RainWorldRandomizer
         /// <summary>
         /// Make passage button appear if any token items have been found
         /// </summary>
-        private static void EngameTokensCtorIL(ILContext il)
+        private static void EndgameTokensCtorIL(ILContext il)
         {
             ILCursor c = new ILCursor(il);
 

--- a/Hooks/SleepScreenHooks.cs
+++ b/Hooks/SleepScreenHooks.cs
@@ -1,6 +1,7 @@
 ﻿using Menu;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
+using MoreSlugcats;
 using RWCustom;
 using System;
 using System.Collections.Generic;
@@ -346,6 +347,16 @@ namespace RainWorldRandomizer
                 }
             }
             passageTokensUI.Add(self, fakePassageTokens);
+
+            // Skip adding button if Riv in Bitter Aerie
+            SaveState state = (menu as SleepAndDeathScreen).saveState;
+            if (ModManager.MSC 
+                && state.saveStateNumber == MoreSlugcatsEnums.SlugcatStatsName.Rivulet
+                && state.miscWorldSaveData.moonHeartRestored
+                && !state.deathPersistentSaveData.altEnding)
+            {
+                return;
+            }
 
             // Add passage to home button
             (menu as SleepAndDeathScreen).CreatePassageHomeButton();

--- a/Hooks/SleepScreenHooks.cs
+++ b/Hooks/SleepScreenHooks.cs
@@ -20,6 +20,7 @@ namespace RainWorldRandomizer
             On.WinState.ConsumeEndGame += ConsumePassageToken;
             On.Menu.EndgameTokens.ctor += OnEndgameTokensCtor;
             On.Menu.SleepAndDeathScreen.Update += OnSleepAndDeathScreenUpdate;
+            On.Menu.SleepAndDeathScreen.UpdateInfoText += OnSleepAndDeathScreenUpdateInfoText;
             On.Menu.SleepAndDeathScreen.Singal += OnSleepAndDeathScreenSingal;
             On.Menu.EndgameTokens.Passage += DoPassage;
             On.Menu.KarmaLadder.ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool += OnKarmaLadderCtor;
@@ -43,6 +44,7 @@ namespace RainWorldRandomizer
             On.WinState.ConsumeEndGame -= ConsumePassageToken;
             On.Menu.EndgameTokens.ctor -= OnEndgameTokensCtor;
             On.Menu.SleepAndDeathScreen.Update -= OnSleepAndDeathScreenUpdate;
+            On.Menu.SleepAndDeathScreen.UpdateInfoText -= OnSleepAndDeathScreenUpdateInfoText;
             On.Menu.SleepAndDeathScreen.Singal -= OnSleepAndDeathScreenSingal;
             On.Menu.EndgameTokens.Passage -= DoPassage;
             On.Menu.KarmaLadder.ctor_Menu_MenuObject_Vector2_HUD_IntVector2_bool -= OnKarmaLadderCtor;
@@ -374,6 +376,21 @@ namespace RainWorldRandomizer
                 button.buttonBehav.greyedOut = self.ButtonsGreyedOut || self.goalMalnourished;
                 button.black = Mathf.Max(0f, button.black - 0.0125f);
             }
+        }
+
+        private static string OnSleepAndDeathScreenUpdateInfoText(On.Menu.SleepAndDeathScreen.orig_UpdateInfoText orig, SleepAndDeathScreen self)
+        {
+            string origResult = orig(self);
+
+            if (self.selectedObject is SimpleButton button)
+            {
+                if (button.signalText.Equals("RETURN_HOME"))
+                {
+                    return self.Translate("Fast travel to the shelter you started the campaign in");
+                }
+            }
+
+            return origResult;
         }
 
         /// <summary>

--- a/Hooks/SleepScreenHooks.cs
+++ b/Hooks/SleepScreenHooks.cs
@@ -5,6 +5,7 @@ using RWCustom;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
@@ -285,8 +286,10 @@ namespace RainWorldRandomizer
 
         // ----- PASSAGE TOKENS -----
         
-        // TODO: This currently doesn't have a cleanup. Isn't a huge deal as it's cleared to refresh every sleep screen, but isn't ideal
-        private static List<FakeEndgameToken> passageTokensUI = new List<FakeEndgameToken>();
+        /// <summary>
+        /// Stores fake passage token UI elements
+        /// </summary>
+        private static ConditionalWeakTable<EndgameTokens, List<FakeEndgameToken>> passageTokensUI = new ConditionalWeakTable<EndgameTokens, List<FakeEndgameToken>>();
 
         /// <summary>
         /// Replace normal passage token list with custom one that contains tokens collected from items rather than tokens from completed passages
@@ -304,7 +307,7 @@ namespace RainWorldRandomizer
                 token.glowSprite.RemoveFromContainer();
             }
 
-            passageTokensUI = new List<FakeEndgameToken>();
+            List<FakeEndgameToken> fakePassageTokens = new List<FakeEndgameToken>();
             int index = 0;
             foreach (WinState.EndgameID id in Plugin.RandoManager.GetPassageTokensStatus().Keys)
             {
@@ -313,11 +316,14 @@ namespace RainWorldRandomizer
                 if ((Plugin.RandoManager.HasPassageToken(id) ?? false)
                     && (menu as KarmaLadderScreen).winState.GetTracker(id, true).consumed == false)
                 {
-                    passageTokensUI.Add(new FakeEndgameToken(menu, self, Vector2.zero, id, container, index));
-                    self.subObjects.Add(passageTokensUI.Last());
+                    fakePassageTokens.Add(new FakeEndgameToken(menu, self, Vector2.zero, id, container, index));
+                    self.subObjects.Add(fakePassageTokens.Last());
                     index++;
                 }
             }
+            passageTokensUI.Add(self, fakePassageTokens);
+
+            
         }
 
         /// <summary>
@@ -393,11 +399,12 @@ namespace RainWorldRandomizer
                 token.glowSprite.RemoveFromContainer();
             }
 
-            for (int i = 0; i < passageTokensUI.Count; i++)
+            List<FakeEndgameToken> fakePassageTokens = passageTokensUI.GetOrCreateValue(self);
+            for (int i = 0; i < fakePassageTokens.Count; i++)
             {
-                if (passageTokensUI[i].id == ID)
+                if (fakePassageTokens[i].id == ID)
                 {
-                    passageTokensUI[i].Activate();
+                    fakePassageTokens[i].Activate();
                     return;
                 }
             }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -109,7 +109,6 @@ namespace RainWorldRandomizer
             // Register Enums
             RandomizerEnums.RegisterAllValues();
             options = new OptionsMenu();
-            Constants.InitializeConstants();
 
             // Create hooks
             try
@@ -221,6 +220,7 @@ namespace RainWorldRandomizer
                 ManagerVanilla.LoadBlacklist(MoreSlugcatsEnums.SlugcatStatsName.Saint);
             }
 
+            Constants.InitializeConstants();
             CustomRegionCompatability.Init();
         }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -109,6 +109,7 @@ namespace RainWorldRandomizer
             // Register Enums
             RandomizerEnums.RegisterAllValues();
             options = new OptionsMenu();
+            Constants.InitializeConstants();
 
             // Create hooks
             try

--- a/SaveManager.cs
+++ b/SaveManager.cs
@@ -25,6 +25,7 @@ namespace RainWorldRandomizer
         {
             StreamWriter file = File.CreateText(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.txt"));
 
+            file.WriteLine($"StartingDen->{Plugin.RandoManager.customStartDen}");
             file.WriteLine(Plugin.RandoManager.currentSeed);
             foreach (var item in game)
             {
@@ -55,8 +56,19 @@ namespace RainWorldRandomizer
 
             string[] file = File.ReadAllLines(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.txt"));
 
-            Plugin.RandoManager.currentSeed = int.Parse(file[0]);
-            file = file.Skip(1).ToArray();
+            if (int.TryParse(file[0], out int seed))
+            {
+                Plugin.RandoManager.currentSeed = seed;
+                file = file.Skip(1).ToArray();
+            }
+            else
+            {
+                // New save file includes additional line to store starting den
+                Plugin.RandoManager.customStartDen = Regex.Split(file[0], "->")[1]; // StartingDen->SU_S01
+                Plugin.RandoManager.currentSeed = int.Parse(file[1]);
+                file = file.Skip(2).ToArray();
+            }
+            
             foreach (string line in file)
             {
                 string[] keyValue = Regex.Split(line, "->");


### PR DESCRIPTION
Added a button on the sleep screen that, when pressed, will passage the player directly to their starting den. In cases where a randomized starting den was not chosen, the button will send them to the den nearest to the slugcat's default starting room.

The Passage isn't really a passage, it doesn't go to any art or selection screen and doesn't increase karma or tick extra cycles. Need to test if it transfers key items, but it should still do that.

Closes #47 