### PR TITLE
Add more traps

### DIFF
--- a/ModCompat/ImprovedCollectibleTrackerCompat.cs
+++ b/ModCompat/ImprovedCollectibleTrackerCompat.cs
@@ -5,9 +5,6 @@ using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MoreSlugcats;
-using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using UnityEngine;
 
 namespace RainWorldRandomizer

--- a/TrapsHandler.cs
+++ b/TrapsHandler.cs
@@ -36,7 +36,7 @@ namespace RainWorldRandomizer
 
             public void Activate(RainWorldGame game)
             {
-                Plugin.Log.LogDebug($"Trap Triggered! ({id})");
+                Plugin.Log.LogInfo($"Trap Triggered! ({id})");
                 Plugin.Singleton.notifQueue.Enqueue($"Trap Triggered! ({id})");
                 definition.onTrigger(game);
                 timer = definition.duration;
@@ -165,7 +165,6 @@ namespace RainWorldRandomizer
         public static void EnqueueTrap(string itemId)
         {
             pendingTrapQueue.Enqueue(new Trap(itemId.Substring(5)));
-            Plugin.Log.LogDebug($"Added trap to queue. Current traps count: {pendingTrapQueue.Count}");
         }
 
         private static void ResetCooldown()

--- a/TrapsHandler.cs
+++ b/TrapsHandler.cs
@@ -115,8 +115,8 @@ namespace RainWorldRandomizer
 
             { "RedLizard", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.RedLizard); }) },
             { "RedCentipede", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.RedCentipede); }) },
-            { "SpitterSpider", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.SpitterSpider); }) },
-            { "BrotherLongLegs", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.BrotherLongLegs); }) },
+            { "SpitterSpider", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.SpitterSpider, 4); }) },
+            { "BrotherLongLegs", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.BrotherLongLegs, 2); }) },
             { "DaddyLongLegs", new TrapDefinition(game => { TrapSpawnCreatureNearby(game, CreatureTemplate.Type.DaddyLongLegs); }) },
         };
 
@@ -254,27 +254,32 @@ namespace RainWorldRandomizer
 
         /// <summary>Spawns the desired creature in an adjacent room</summary>
         /// <param name="template">The type of creature to spawn</param>
-        private static void TrapSpawnCreatureNearby(this RainWorldGame game, CreatureTemplate.Type template)
+        /// <param name="count">How many of the creature to spawn</param>
+        private static void TrapSpawnCreatureNearby(this RainWorldGame game, CreatureTemplate.Type template, int count = 1)
         {
             Player player = game.FirstAlivePlayer?.realizedCreature as Player;
 
             int[] connectedRooms = player.room.abstractRoom.connections;
-            AbstractRoom chosenRoom = game.world.GetAbstractRoom(connectedRooms[UnityEngine.Random.Range(0, connectedRooms.Length)]);
 
-            if (chosenRoom == null)
+            for (int i = 0; i < count; i++)
             {
-                Plugin.Log.LogError("Trap failed to find a valid room to spawn creature in");
-                return;
-            }
+                AbstractRoom chosenRoom = game.world.GetAbstractRoom(connectedRooms[UnityEngine.Random.Range(0, connectedRooms.Length)]);
 
-            AbstractCreature crit = new AbstractCreature(game.world, StaticWorld.GetCreatureTemplate(template), null, chosenRoom.RandomNodeInRoom(), game.GetNewID());
+                if (chosenRoom == null)
+                {
+                    Plugin.Log.LogError("Trap failed to find a valid room to spawn creature in");
+                    return;
+                }
 
-            chosenRoom.AddEntity(crit);
+                AbstractCreature crit = new AbstractCreature(game.world, StaticWorld.GetCreatureTemplate(template), null, chosenRoom.RandomNodeInRoom(), game.GetNewID());
 
-            if (chosenRoom.realizedRoom != null)
-            {
-                crit.RealizeInRoom();
-                crit.abstractAI.RealAI.tracker.SeeCreature(player.abstractCreature);
+                chosenRoom.AddEntity(crit);
+
+                if (chosenRoom.realizedRoom != null)
+                {
+                    crit.RealizeInRoom();
+                    crit.abstractAI.RealAI.tracker.SeeCreature(player.abstractCreature);
+                }
             }
         }
 

--- a/TrapsHandler.cs
+++ b/TrapsHandler.cs
@@ -267,7 +267,7 @@ namespace RainWorldRandomizer
                 if (chosenRoom == null)
                 {
                     Plugin.Log.LogError("Trap failed to find a valid room to spawn creature in");
-                    return;
+                    continue;
                 }
 
                 AbstractCreature crit = new AbstractCreature(game.world, StaticWorld.GetCreatureTemplate(template), null, chosenRoom.RandomNodeInRoom(), game.GetNewID());


### PR DESCRIPTION
Adds several new trap types:
- Gravity trap creates 0G around the player for 30 seconds. Does not apply to rooms with gravity effects already present
- Rain trap triggers precycle rain for 15 seconds. Seems to not fully work for flooding
  - Duration may need tweaking, 15 seconds feels short but we also don't want to stunlock the player for any large amount of time
- Some creature traps now spawn multiple creatures. BLL spawns 2 and Spitter Spider spawns 4
  - May want to play around with these numbers, we want the weaker creatures to be dangerous but balanced to provide a similar threat as red lizards / centipedes

Creature traps overall feel lackluster currently, due to the relatively high likelihood they spawn in a room you don't end up visiting. Maybe some work can be done later to urge them to pathfind to the room that the player is in, as `SeeCreature()` is not enough for this.

Closes #81 