### PR TITLE
Chatlog upgrade

### DIFF
--- a/Archipelago/ArchipelagoConnection.cs
+++ b/Archipelago/ArchipelagoConnection.cs
@@ -65,22 +65,22 @@ namespace RainWorldRandomizer
         /// <summary>
         /// Defined palette for the mod to use when displaying colors
         /// </summary>
-        public static Palette<UnityEngine.Color> palette =
-            new Palette<UnityEngine.Color>(
+        public static Palette<Color> palette =
+            new Palette<Color>(
                 Menu.Menu.MenuRGB(Menu.Menu.MenuColors.White),
-                new Dictionary<PaletteColor, UnityEngine.Color>()
+                new Dictionary<PaletteColor, Color>()
                 {
                     { PaletteColor.Black, Menu.Menu.MenuRGB(Menu.Menu.MenuColors.Black) },
-                    { PaletteColor.Blue, new UnityEngine.Color(0f, 0f, 1f) },
-                    { PaletteColor.Cyan, new UnityEngine.Color(0f, 1f, 1f) },
-                    { PaletteColor.Green, new UnityEngine.Color(0, 0.5f, 0f) },
-                    { PaletteColor.Magenta, new UnityEngine.Color(1f, 0f, 1f) },
-                    { PaletteColor.Plum, new UnityEngine.Color(0.85f, 0.6f, 0.85f) },
-                    { PaletteColor.Red, new UnityEngine.Color(1f, 0f, 0f) },
-                    { PaletteColor.Salmon, new UnityEngine.Color(0.98f, 0.5f, 0.45f) },
-                    { PaletteColor.SlateBlue, new UnityEngine.Color(0.4f, 0.35f, 0.8f) },
-                    { PaletteColor.White, new UnityEngine.Color(1f, 1f, 1f) },
-                    { PaletteColor.Yellow, new UnityEngine.Color(1f, 1f, 0f) }
+                    { PaletteColor.Blue, new Color(0f, 0f, 1f) },
+                    { PaletteColor.Cyan, new Color(0f, 1f, 1f) },
+                    { PaletteColor.Green, new Color(0, 0.5f, 0f) },
+                    { PaletteColor.Magenta, new Color(1f, 0f, 1f) },
+                    { PaletteColor.Plum, new Color(0.85f, 0.6f, 0.85f) },
+                    { PaletteColor.Red, new Color(1f, 0f, 0f) },
+                    { PaletteColor.Salmon, new Color(0.98f, 0.5f, 0.45f) },
+                    { PaletteColor.SlateBlue, new Color(0.4f, 0.35f, 0.8f) },
+                    { PaletteColor.White, new Color(1f, 1f, 1f) },
+                    { PaletteColor.Yellow, new Color(1f, 1f, 0f) }
                 }
             );
 
@@ -564,7 +564,7 @@ namespace RainWorldRandomizer
                 && !(message is TagsChangedLogMessage) // Filter out tag change logs
                 && (!(message is ChatLogMessage chatMessage) || !chatMessage.Message.StartsWith("!"))) // Filter out chat commands
             {
-                Plugin.Singleton.notifQueueAP.Enqueue(message);
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText(message));
             }
         }
 
@@ -576,7 +576,7 @@ namespace RainWorldRandomizer
             {
                 Disconnect(false);
                 Plugin.Log.LogError("Disconnected Socket due to WebSocketException");
-                Plugin.Singleton.notifQueue.Enqueue("You have been disconnected due to an exception. Please attempt to reconnect.");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("You have been disconnected due to an exception. Please attempt to reconnect.", Color.red));
             }
         }
 

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -31,7 +31,7 @@ namespace RainWorldRandomizer
             {
                 Plugin.Log.LogError("Tried to start AP campaign without first connecting to server");
                 isRandomizerActive = false;
-                Plugin.Singleton.notifQueue.Enqueue("Archipelago failed to start: Not connected to a server");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("Archipelago failed to start: Not connected to a server", UnityEngine.Color.red));
             }
 
             base.StartNewGameSession(storyGameCharacter, continueSaved);
@@ -43,7 +43,7 @@ namespace RainWorldRandomizer
                     $"\n Chosen campaign: {storyGameCharacter}" +
                     $"\n Chosen AP option: {ArchipelagoConnection.Slugcat}");
                 isRandomizerActive = false;
-                Plugin.Singleton.notifQueue.Enqueue("Archipelago failed to start: Selected campaign does not match archipelago options.");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("Archipelago failed to start: Selected campaign does not match archipelago options.", UnityEngine.Color.red));
                 return;
             }
 
@@ -52,7 +52,7 @@ namespace RainWorldRandomizer
             {
                 Plugin.Log.LogError("Failed to initialize randomizer.");
                 isRandomizerActive = false;
-                Plugin.Singleton.notifQueue.Enqueue($"Randomizer failed to initialize. Check logs for details.");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText($"Randomizer failed to initialize. Check logs for details.", UnityEngine.Color.red));
                 return;
             }
 
@@ -351,7 +351,7 @@ namespace RainWorldRandomizer
             gameCompleted = true;
             ArchipelagoConnection.SendCompletion();
             Plugin.Log.LogInfo("Game Complete!");
-            Plugin.Singleton.notifQueue.Enqueue("Game Complete!");
+            Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("Game Complete!", UnityEngine.Color.green));
         }
 
         public override void SaveGame(bool saveCurrentState)

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -73,7 +73,7 @@ namespace RainWorldRandomizer
                     }
                     catch (Exception e)
                     {
-                        Plugin.Singleton.notifQueue.Enqueue("Failed to start randomizer game. More details found in BepInEx/LogOutput.log");
+                        Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("Failed to start randomizer game. More details found in BepInEx/LogOutput.log", UnityEngine.Color.red));
                         Plugin.Log.LogError("Encountered exception while starting game session");
                         Plugin.Log.LogError(e);
                     }
@@ -268,22 +268,6 @@ namespace RainWorldRandomizer
             if (self.GamePaused || !self.processActive) return;
 
             // Display any pending notifications
-            if (Plugin.Singleton.notifQueueAP.Count > 0)
-            {
-                if (RandoOptions.DisableNotificationQueue)
-                {
-                    Plugin.Singleton.notifQueueAP.Dequeue();
-                }
-                else if (RandoOptions.legacyNotifications.Value)
-                {
-                    Plugin.Singleton.DisplayLegacyNotification(true);
-                }
-                else if (HudExtension.CurrentChatLog != null)
-                {
-                    HudExtension.CurrentChatLog.AddMessage(Plugin.Singleton.notifQueueAP.Dequeue());
-                }
-            }
-            // Display plain text messages last, as they tend to be more important
             else if (Plugin.Singleton.notifQueue.Count > 0)
             {
                 if (RandoOptions.DisableNotificationQueue)
@@ -292,7 +276,7 @@ namespace RainWorldRandomizer
                 }
                 else if (RandoOptions.legacyNotifications.Value)
                 {
-                    Plugin.Singleton.DisplayLegacyNotification(false);
+                    Plugin.Singleton.DisplayLegacyNotification();
                 }
                 else if (HudExtension.CurrentChatLog != null)
                 {

--- a/Hooks/MiscHooks.cs
+++ b/Hooks/MiscHooks.cs
@@ -125,7 +125,7 @@ namespace RainWorldRandomizer
                 if (Plugin.RandoManager.customStartDen.Equals(""))
                 {
                     Plugin.Log.LogError("Tried to set starting den while custom den unset");
-                    Plugin.Singleton.notifQueue.Enqueue("ERROR: Failed to set correct starting den");
+                    Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("ERROR: Failed to set correct starting den", UnityEngine.Color.red));
                     return;
                 }
                 self.denPosition = Plugin.RandoManager.customStartDen;

--- a/ManagerVanilla.cs
+++ b/ManagerVanilla.cs
@@ -31,7 +31,7 @@ namespace RainWorldRandomizer
             {
                 Plugin.Log.LogWarning("Selected incompatible save, disabling randomizer");
                 isRandomizerActive = false;
-                Plugin.Singleton.notifQueue.Enqueue($"WARNING: This campaign is not currently supported by Check Randomizer. It will not be active for this session.");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText($"WARNING: This campaign is not currently supported by Check Randomizer. It will not be active for this session.", Color.red));
                 return;
             }
 
@@ -77,7 +77,7 @@ namespace RainWorldRandomizer
                 {
                     Plugin.Log.LogError("Failed to load saved game.");
                     isRandomizerActive = false;
-                    Plugin.Singleton.notifQueue.Enqueue($"Randomizer failed to find valid save for current file");
+                    Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText($"Randomizer failed to find valid save for current file", Color.red));
                     return;
                 }
             }
@@ -124,11 +124,13 @@ namespace RainWorldRandomizer
                     if (generator.CurrentStage == VanillaGenerator.GenerationStep.FailedGen
                         && generationException.InnerException is VanillaGenerator.GenerationFailureException)
                     {
-                        Plugin.Singleton.notifQueue.Enqueue($"Randomizer failed to generate with error: {generationException.InnerException.Message}. More details found in BepInEx/LogOutput.log");
+                        Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText(
+                            $"Randomizer failed to generate with error: {generationException.InnerException.Message}. More details found in BepInEx/LogOutput.log",
+                            Color.red));
                     }
                     else
                     {
-                        Plugin.Singleton.notifQueue.Enqueue($"Randomizer failed to generate. More details found in BepInEx/LogOutput.log");
+                        Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText($"Randomizer failed to generate. More details found in BepInEx/LogOutput.log", Color.red));
                     }
                     return;
                 }
@@ -136,7 +138,7 @@ namespace RainWorldRandomizer
 
             isRandomizerActive = true;
         }
-        
+
         public void DebugBulkGeneration(int howMany)
         {
             VanillaGenerator[] generators = new VanillaGenerator[howMany];
@@ -226,7 +228,7 @@ namespace RainWorldRandomizer
                         if (item.IsGiven) _givenSpearPearlRewrite = true;
                         break;
                 }
-                
+
             }
 
             Plugin.Singleton.itemDeliveryQueue = SaveManager.LoadItemQueue(slugcat, saveSlot);
@@ -255,7 +257,7 @@ namespace RainWorldRandomizer
             if (IsLocationGiven(location) ?? true) return false;
 
             randomizerKey[location].GiveUnlock();
-            Plugin.Singleton.notifQueue.Enqueue(randomizerKey[location].UnlockCompleteMessage());
+            Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText(randomizerKey[location].UnlockCompleteMessage()));
             Plugin.Log.LogInfo($"Completed Check: {location}");
 
             return true;

--- a/Menu/HudExtension.cs
+++ b/Menu/HudExtension.cs
@@ -74,8 +74,6 @@ namespace RainWorldRandomizer
             pos = new Vector2(hud.rainWorld.options.ScreenSize.x - MSG_SIZE_X - (MSG_MARGIN * 2) + 0.01f, 30.01f);
 
             // A whole bunch of test messages for debugging
-
-
             /*
             AddMessage("");
             AddMessage("This is a message showcasing the new Icon system. I can display anything I want, such as Icon{BubbleGrass}, " +
@@ -107,33 +105,14 @@ namespace RainWorldRandomizer
             */
         }
 
-        public void AddMessage(string text)
+        public void AddMessage(MessageText message)
         {
-            AddMessage(text, Color.white);
-        }
-
-        public void AddMessage(string text, Color color)
-        {
-            if (text == "") return; // Empty strings break messages
-            string[] strings = new string[] { text };
-            Color[] colors = new Color[] { color };
-            AddMessage(strings, colors);
-        }
-
-        public void AddMessage(LogMessage logMessage)
-        {
-            string[] strings = logMessage.Parts.Select(p => p.Text).ToArray();
-            Color[] colors = logMessage.Parts.Select(p => ArchipelagoConnection.palette[p.PaletteColor]).ToArray();
-            AddMessage(strings, colors);
-        }
-
-        public void AddMessage(string[] strings, Color[] colors)
-        {
-            if (strings.Length != colors.Length)
+            // Empty strings break messages
+            if (message.strings.Contains(""))
             {
-                throw new ArgumentException("Both array arguments must be of the same length");
+                Plugin.Log.LogWarning($"Chatlog tried to print invalid message: \"{string.Join("", message.strings)}\"");
             }
-            EnqueueMessage(new ChatMessage(this, strings, colors));
+            EnqueueMessage(new ChatMessage(this, message.strings, message.colors));
         }
 
         private void EnqueueMessage(ChatMessage message)
@@ -185,6 +164,43 @@ namespace RainWorldRandomizer
             // Making an assumption that if something is clearing our sprites,
             // we should not exist anymore.
             hud.parts.Remove(this);
+        }
+
+        /// <summary>
+        /// Simple struct for storing messages before creating their UI
+        /// </summary>
+        public struct MessageText
+        {
+            public string[] strings;
+            public Color[] colors;
+
+            /// <summary>Single part white message</summary>
+            public MessageText(string message)
+            {
+                strings = new string[] { message };
+                colors = new Color[] { Color.white };
+            }
+
+            /// <summary>Single part colored message</summary>
+            public MessageText(string message, Color color)
+            {
+                strings = new string[] { message };
+                colors = new Color[] { color };
+            }
+
+            /// <summary> Multi-part colored message</summary>
+            public MessageText(string[] strings, Color[] colors)
+            {
+                this.strings = strings;
+                this.colors = colors;
+            }
+
+            /// <summary>Import a message from an Archipelago <see cref="LogMessage"/></summary>
+            public MessageText(LogMessage logMessage)
+            {
+                strings = logMessage.Parts.Select(p => p.Text).ToArray();
+                colors = logMessage.Parts.Select(p => ArchipelagoConnection.palette[p.PaletteColor]).ToArray();
+            }
         }
 
         private class ChatMessage

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -47,8 +47,8 @@ namespace RainWorldRandomizer
             }
         }
 
-        public Queue<string> notifQueue = new Queue<string>(); // Queue of pending notifications to be sent to the player in-game
-        public Queue<LogMessage> notifQueueAP = new Queue<LogMessage>();
+        // Queue of pending notifications to be sent to the player in-game
+        public Queue<ChatLog.MessageText> notifQueue = new Queue<ChatLog.MessageText>();
         // Queue of items that the player has recieved and not claimed
         public Queue<Unlock.Item> lastItemDeliveryQueue = new Queue<Unlock.Item>();
         public Queue<Unlock.Item> itemDeliveryQueue = new Queue<Unlock.Item>();
@@ -456,12 +456,12 @@ namespace RainWorldRandomizer
             }
         }
 
-        public void DisplayLegacyNotification(bool fromAP)
+        public void DisplayLegacyNotification()
         {
             if (Game == null) return;
 
             // If there are several messages waiting, move through them quicker
-            bool hurry = notifQueue.Count + notifQueueAP.Count > 3;
+            bool hurry = notifQueue.Count > 3;
             // If we have any pending messages and are in the actual game loop
 
             if (Game.session.Players[0]?.realizedCreature?.room != null
@@ -470,7 +470,7 @@ namespace RainWorldRandomizer
                 && Game.manager.currentMainLoop.ID == ProcessManager.ProcessID.Game)
 
             {
-                string message = fromAP ? notifQueueAP.Dequeue().ToString() : notifQueue.Dequeue();
+                string message = string.Join("", notifQueue.Dequeue().strings);
                 if (message.Contains("//"))
                 {
                     string[] split = Regex.Split(message, "//");

--- a/TrapsHandler.cs
+++ b/TrapsHandler.cs
@@ -37,7 +37,8 @@ namespace RainWorldRandomizer
             public void Activate(RainWorldGame game)
             {
                 Plugin.Log.LogInfo($"Trap Triggered! ({id})");
-                Plugin.Singleton.notifQueue.Enqueue($"Trap Triggered! ({id})");
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText($"Trap Triggered! ({id})", 
+                    ArchipelagoConnection.palette[Archipelago.MultiClient.Net.Colors.PaletteColor.Red]));
                 definition.onTrigger(game);
                 timer = definition.duration;
 

--- a/Unlock.cs
+++ b/Unlock.cs
@@ -309,7 +309,7 @@ namespace RainWorldRandomizer
         public static void ShowItemTutorial()
         {
             if (hasSeenItemTutorial || RandoOptions.ItemShelterDelivery || Plugin.RandoManager is ManagerArchipelago) return;
-            Plugin.Singleton.notifQueue.Enqueue("TIP: Unlocked items are stored in your stomach for safe keeping");
+            Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("TIP: Unlocked items are stored in your stomach for safe keeping"));
             hasSeenItemTutorial = true;
         }
     }


### PR DESCRIPTION
The chatlog has been rewritten to support additional features, as well as fix bugs with the old text wrapping solution.

Both normal string messages are now handled identically. A chat message can support multiple colors, as well as icons when a special pattern is typed.

Any `MultiplayerUnlocks.SandboxUnlockID` can be typed inside curly braces following the word "Icon", like so:
`Icon{WaterNut}`
`Icon{RedLizard}`
`Icon{Slugcat}`
`Icon{EnergyCell}`
The respective Icon symbol will appear to replace the string wherever it is typed when displayed in-game

Closes #80.