### PR TITLE
Move more data into token cache

### DIFF
--- a/Generation/State.cs
+++ b/Generation/State.cs
@@ -132,18 +132,19 @@ namespace RainWorldRandomizer.Generation
             // Add any new region's placed objects
             foreach (string region in Regions)
             {
-                for (int i = 0; i < TokenCachePatcher.regionObjects[region].Count; i++)
+                string regionLower = region.ToLowerInvariant();
+                for (int i = 0; i < TokenCachePatcher.regionObjects[regionLower].Count; i++)
                 {
-                    if (TokenCachePatcher.regionObjectsAccessibility[region][i].Contains(Slugcat))
+                    if (TokenCachePatcher.regionObjectsAccessibility[regionLower][i].Contains(Slugcat))
                     {
-                        Objects.Add(TokenCachePatcher.regionObjects[region][i]);
+                        Objects.Add(TokenCachePatcher.regionObjects[regionLower][i]);
                     }
                 }
-                for (int j = 0; j < TokenCachePatcher.regionCreatures[region].Count; j++)
+                for (int j = 0; j < TokenCachePatcher.regionCreatures[regionLower].Count; j++)
                 {
-                    if (TokenCachePatcher.regionCreaturesAccessibility[region][j].Contains(Slugcat))
+                    if (TokenCachePatcher.regionCreaturesAccessibility[regionLower][j].Contains(Slugcat))
                     {
-                        Creatures.Add(TokenCachePatcher.regionCreatures[region][j]);
+                        Creatures.Add(TokenCachePatcher.regionCreatures[regionLower][j]);
                     }
                 }
             }

--- a/Generation/VanillaGenerator.cs
+++ b/Generation/VanillaGenerator.cs
@@ -443,23 +443,18 @@ namespace RainWorldRandomizer.Generation
                     else
                     {
                         AccessRule rule = new ObjectAccessRule(data.type);
-                        if (data.type == AbstractPhysicalObject.AbstractObjectType.SSOracleSwarmer)
-                        {
-                            rule = AccessRuleConstants.NeuronAccess;
-                        }
-
                         allGourmRules.Add(rule);
                         locations.Add(new Location($"FoodQuest-{data.type.value}", Location.Type.Food, rule));
                     }
-                    locations.Add(new Location("Passage-Gourmand", Location.Type.Passage,
-                        new CompoundAccessRule(allGourmRules.ToArray(), CompoundAccessRule.CompoundOperation.All)));
                 }
+                locations.Add(new Location("Passage-Gourmand", Location.Type.Passage,
+                        new CompoundAccessRule(allGourmRules.ToArray(), CompoundAccessRule.CompoundOperation.All)));
             }
 
             // Create Special locations
             if (RandoOptions.UseSpecialChecks)
             {
-                locations.Add(new Location("Eat_Neuron", Location.Type.Story, AccessRuleConstants.NeuronAccess));
+                locations.Add(new Location("Eat_Neuron", Location.Type.Story, new ObjectAccessRule(AbstractPhysicalObject.AbstractObjectType.SSOracleSwarmer)));
 
                 switch (slugcat.value)
                 {
@@ -915,20 +910,6 @@ namespace RainWorldRandomizer.Generation
             }, CompoundAccessRule.CompoundOperation.All);
             GlobalRuleOverrides.Add("Echo-SB", subRavineRule);
             GlobalRuleOverrides.Add("Pearl-SB_ravine", subRavineRule);
-
-            // TODO: Add effect detection for Batflies and Neurons
-            // This is temporary until there's a way to detect batflies in a region
-            GlobalRuleOverrides.Add("FoodQuest-Fly", new CompoundAccessRule(AccessRuleConstants.Regions,
-                CompoundAccessRule.CompoundOperation.AtLeast, 5));
-            // TODO: Add support for creatures that are PlacedObjects
-            GlobalRuleOverrides.Add("FoodQuest-Hazer", new CompoundAccessRule(new AccessRule[]
-            {
-                new RegionAccessRule("LF"),
-                new RegionAccessRule("DS"),
-                new RegionAccessRule("GW"),
-                new RegionAccessRule("HI"),
-                new RegionAccessRule("SL")
-            }, CompoundAccessRule.CompoundOperation.Any));
 
             // MSC specific rules
             if (ModManager.MSC)


### PR DESCRIPTION
Now calculates and stores data for object, creature, and room accessibility all at the same time, and stores them in custom token cache.
Allows additional accessibility to be calculated rather than hardcoded (Neurons, Hazers, Batflies)