### PR TITLE
Force token cache reload whenever randomizer is missing it

### DIFF
--- a/TokenCachePatcher.cs
+++ b/TokenCachePatcher.cs
@@ -72,21 +72,7 @@ namespace RainWorldRandomizer
             c.Emit(OpCodes.Brfalse, jump);
             c.Emit(OpCodes.Ldloc, 15);
 
-            static bool ForceBuildCache(bool fileExists)
-            {
-                string path = AssetManager.ResolveFilePath(string.Join("",
-                [
-                    "World",
-                    Path.DirectorySeparatorChar.ToString(),
-                    "IndexMaps",
-                    Path.DirectorySeparatorChar.ToString(),
-                    Path.DirectorySeparatorChar.ToString(),
-                    "randomizercachesu.txt" // Arbitrary part of randomizer cache to validate it exists
-                ]));
-
-                return fileExists || !File.Exists(path);
-            }
-
+            static bool ForceBuildCache(bool fileExists) => true;
             static bool CancelDeleteFile(string filePath) => File.Exists(filePath);
         }
 


### PR DESCRIPTION
Token cache previously would reload after applying mods only if Remix or Watcher were enabled. This makes it additionally reload it when randomizer is active.

Also made it reload mods (and thus, token cache) on startup if data is needed. The "is needed" check right now simply checks if there is any data for Outskirts, which isn't the most foolproof but is better than reloading mods every startup
