### PR TITLE
Scavengers will not scavenge certain items needed for checks

### DIFF
--- a/Hooks/MiscHooks.cs
+++ b/Hooks/MiscHooks.cs
@@ -683,9 +683,19 @@ namespace RainWorldRandomizer
             {
                 PhysicalObject obj = self.itemTracker.GetRep(j).representedItem.realizedObject;
                 // Do not take unpicked flowers
-                if (obj is KarmaFlower flower && flower.growPos is not null) return true;
+                if (RandoOptions.UseKarmaFlowerChecks
+                    && obj is KarmaFlower flower
+                    && flower.growPos is not null)
+                {
+                    return true;
+                }
                 // Do not take unique data pearls
-                if (obj is DataPearl pearl && DataPearl.PearlIsNotMisc(pearl.AbstractPearl.dataPearlType)) return true;
+                if (RandoOptions.UsePearlChecks
+                    && obj is DataPearl pearl
+                    && DataPearl.PearlIsNotMisc(pearl.AbstractPearl.dataPearlType))
+                {
+                    return true;
+                }
                 return false;
             }
         }

--- a/Hooks/MiscHooks.cs
+++ b/Hooks/MiscHooks.cs
@@ -649,6 +649,11 @@ namespace RainWorldRandomizer
             return orig(itemType, intdata);
         }
 
+        /// <summary>
+        /// Restrict scavengers from taking certain objects from the ground on their own
+        /// to avoid needed items for checks disappearing. 
+        /// This only stops them from taking things they found, will not prevent player gifting them
+        /// </summary>
         private static void CheckForScavengeItemsIL(ILContext il)
         {
             ILCursor c = new(il);

--- a/Hooks/MiscHooks.cs
+++ b/Hooks/MiscHooks.cs
@@ -64,6 +64,7 @@ namespace RainWorldRandomizer
                 IL.MoreSlugcats.GourmandMeter.UpdatePredictedNextItem += ILFoodQuestUpdateNextPredictedItem;
                 IL.DeathPersistentSaveData.CanUseUnlockedGates += CanUseUnlockedGatesIL;
                 IL.World.SpawnGhost += ILSpawnGhost;
+                IL.ScavengerAI.CheckForScavangeItems += CheckForScavengeItemsIL;
             }
             catch (Exception e)
             {
@@ -94,6 +95,7 @@ namespace RainWorldRandomizer
             IL.MoreSlugcats.GourmandMeter.UpdatePredictedNextItem -= ILFoodQuestUpdateNextPredictedItem;
             IL.DeathPersistentSaveData.CanUseUnlockedGates -= CanUseUnlockedGatesIL;
             IL.World.SpawnGhost -= ILSpawnGhost;
+            IL.ScavengerAI.CheckForScavangeItems += CheckForScavengeItemsIL;
         }
 
         /// <summary>
@@ -645,6 +647,47 @@ namespace RainWorldRandomizer
         {
             if (itemType == AbstractPhysicalObject.AbstractObjectType.SeedCob) return new Color(0.4117f, 0.1608f, 0.2275f);
             return orig(itemType, intdata);
+        }
+
+        private static void CheckForScavengeItemsIL(ILContext il)
+        {
+            ILCursor c = new(il);
+            ILLabel continueJump;
+            int localForIterationVar = -1;
+
+            // Find for loop iteration at 0102
+            c.GotoNext(
+                x => x.MatchCallOrCallvirt(typeof(ItemTracker).GetProperty(nameof(ItemTracker.ItemCount)).GetGetMethod()),
+                x => x.MatchBlt(out _)
+                );
+            c.GotoPrev(MoveType.Before,
+                x => x.MatchLdcI4(1),
+                x => x.MatchAdd(),
+                x => x.MatchStloc(out localForIterationVar)
+                );
+            continueJump = c.MarkLabel();
+
+            // After assigning PickUpItemScore to a local at 0072
+            c.GotoPrev(MoveType.After,
+                x => x.MatchCallOrCallvirt(typeof(ScavengerAI).GetMethod(nameof(ScavengerAI.PickUpItemScore), BindingFlags.Instance | BindingFlags.NonPublic)),
+                x => x.MatchStloc(out _)
+                );
+
+            // Emit a conditional jump to the next loop iteration if the current item should not be scavenged
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit(OpCodes.Ldloc, localForIterationVar);
+            c.EmitDelegate(ShouldNotScavengeItem);
+            c.Emit(OpCodes.Brtrue, continueJump);
+
+            static bool ShouldNotScavengeItem(ScavengerAI self, int j)
+            {
+                PhysicalObject obj = self.itemTracker.GetRep(j).representedItem.realizedObject;
+                // Do not take unpicked flowers
+                if (obj is KarmaFlower flower && flower.growPos is not null) return true;
+                // Do not take unique data pearls
+                if (obj is DataPearl pearl && DataPearl.PearlIsNotMisc(pearl.AbstractPearl.dataPearlType)) return true;
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Restricts scavengers from picking up unpicked karma flowers and colored pearls. This should resolve the occasional issue of these items seeming to vanish before the player can reach them to collect checks.

These restrictions will only apply if the relevant items are set to be randomized, so behavior will be normal when those checks are not needed.

Currently untested
