### PR TITLE
Add traps to standalone

### DIFF
--- a/Generation/Item.cs
+++ b/Generation/Item.cs
@@ -12,6 +12,7 @@ namespace RainWorldRandomizer.Generation
             Passage,
             Karma,
             Object,
+            Trap,
             Other
         }
         public enum Importance
@@ -59,6 +60,20 @@ namespace RainWorldRandomizer.Generation
             { "Object-ElectricSpear", 3 },
             { "Object-SingularityBomb", 1 },
         };
+        public static readonly Dictionary<string, int> trapWeights = new()
+        {
+            { "Trap-Stun", 6 },
+            { "Trap-Zoomies", 5 },
+            { "Trap-Timer", 5 },
+            { "Trap-Rain", 5 },
+            { "Trap-Alarm", 3 },
+            { "Trap-RedLizard", 3 },
+            { "Trap-RedCentipede", 3 },
+            { "Trap-SpitterSpider", 3 },
+            { "Trap-BrotherLongLegs", 3 },
+            { "Trap-DaddyLongLegs", 1 },
+            { "Trap-Gravity", 1 },
+        };
 
         public static Item RandomJunkItem(ref Random random)
         {
@@ -85,6 +100,28 @@ namespace RainWorldRandomizer.Generation
             }
 
             return new Item("Object-Rock", Type.Object, Importance.Filler);
+        }
+
+        public static Item RandomTrapItem(ref Random random)
+        {
+            List<string> items = [.. trapWeights.Keys];
+            List<int> weights = [.. trapWeights.Values];
+
+            int sum = weights.Sum();
+            int randomValue = random.Next(sum + 1);
+
+            int cursor = 0;
+            for (int i = 0; i < items.Count; i++)
+            {
+                cursor += weights[i];
+                if (cursor >= randomValue)
+                {
+                    return new Item(items[i], Type.Trap, Importance.Filler);
+                }
+            }
+
+            return new Item("Trap-Stun", Type.Trap, Importance.Filler);
+
         }
     }
 }

--- a/Generation/VanillaGenerator.cs
+++ b/Generation/VanillaGenerator.cs
@@ -724,7 +724,7 @@ namespace RainWorldRandomizer.Generation
                     itemsToAdd.Add(new Item("HunterCycles", Item.Type.Other, Item.Importance.Filler));
                     hunterCyclesAdded++;
                 }
-                else if (trapsAdded < state.AllLocations.Count * 0.3f)
+                else if (trapsAdded < state.AllLocations.Count * RandoOptions.TrapsDensity)
                 {
                     // Add trap items
                     itemsToAdd.Add(Item.RandomTrapItem(ref randomState));

--- a/Generation/VanillaGenerator.cs
+++ b/Generation/VanillaGenerator.cs
@@ -730,21 +730,10 @@ namespace RainWorldRandomizer.Generation
                     itemsToAdd.Add(Item.RandomTrapItem(ref randomState));
                     trapsAdded++;
                 }
-                else if (RandoOptions.GiveObjectItems)
+                else
                 {
                     // Add junk items
                     itemsToAdd.Add(Item.RandomJunkItem(ref randomState));
-                }
-                else
-                {
-                    // Duplicate a random gate item
-                    IEnumerable<Item> gateItems = itemsToPlace.Where(i => i.type == Item.Type.Gate);
-                    Item gate = new(gateItems.ElementAt(randomState.Next(gateItems.Count())))
-                    {
-                        importance = Item.Importance.Filler
-                    };
-                    itemsToAdd.Add(gate);
-                    generationLog.AppendLine($"Added duplicate gate item: {gate}");
                 }
             }
 

--- a/Generation/VanillaGenerator.cs
+++ b/Generation/VanillaGenerator.cs
@@ -714,6 +714,7 @@ namespace RainWorldRandomizer.Generation
 
             List<Item> itemsToAdd = [];
             int hunterCyclesAdded = 0;
+            int trapsAdded = 0;
             while (state.AllLocations.Count > itemsToPlace.Count + itemsToAdd.Count)
             {
                 if (slugcat == SlugcatStats.Name.Red
@@ -722,6 +723,12 @@ namespace RainWorldRandomizer.Generation
                     // Add cycle increases for Hunter
                     itemsToAdd.Add(new Item("HunterCycles", Item.Type.Other, Item.Importance.Filler));
                     hunterCyclesAdded++;
+                }
+                else if (trapsAdded < state.AllLocations.Count * 0.3f)
+                {
+                    // Add trap items
+                    itemsToAdd.Add(Item.RandomTrapItem(ref randomState));
+                    trapsAdded++;
                 }
                 else if (RandoOptions.GiveObjectItems)
                 {
@@ -947,6 +954,9 @@ namespace RainWorldRandomizer.Generation
                 case Item.Type.Object:
                     if (item.id.StartsWith("PearlObject-")) outputType = Unlock.UnlockType.ItemPearl;
                     else outputType = Unlock.UnlockType.Item;
+                    break;
+                case Item.Type.Trap:
+                    outputType = Unlock.UnlockType.Trap;
                     break;
                 case Item.Type.Other:
                     if (ExtEnumBase.TryParse(typeof(Unlock.UnlockType), item.id, false, out ExtEnumBase type))

--- a/Menu/MenuExtension.cs
+++ b/Menu/MenuExtension.cs
@@ -77,7 +77,7 @@ namespace RainWorldRandomizer
 
             self.pages[0].subObjects.Add(gateDisplay);
 
-            if (RandoOptions.GiveObjectItems && Plugin.Singleton.itemDeliveryQueue.Count > 0)
+            if (Plugin.Singleton.itemDeliveryQueue.Count > 0)
             {
                 PendingItemsDisplay pendingItemsDisplay = new(self, self.pages[0],
                     new Vector2((1366f - manager.rainWorld.screenSize.x) / 2f + xOffset, manager.rainWorld.screenSize.y - gateDisplay.size.y - 20f));

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -305,8 +305,33 @@ namespace RainWorldRandomizer
             globalGroup.AddCheckBox(RandoOptions.legacyNotifications, new(RIGHT_OPTION_X, runningY));
             runningY -= NEWLINE_DECREMENT;
             globalGroup.AddCheckBox(RandoOptions.useGateMap, new(RIGHT_OPTION_X, runningY));
+            runningY -= NEWLINE_DECREMENT * 1.65f;
             globalGroup.AddToTab(tabIndex);
             optionGroups.Add(globalGroup);
+
+            OptionGroup trapGroup = new(this, "Traps", new(10f, 10f), new(GROUP_SIZE_X, 0f));
+            OpUpdown trapMinUpDown = trapGroup.AddUpDown(RandoOptions.trapMinimumCooldown, true, new(RIGHT_OPTION_X, runningY), 60f);
+            runningY -= NEWLINE_DECREMENT;
+            OpUpdown trapMaxUpDown = trapGroup.AddUpDown(RandoOptions.trapMaximumCooldown, true, new(RIGHT_OPTION_X, runningY), 60f);
+            runningY -= NEWLINE_DECREMENT;
+            trapGroup.AddToTab(tabIndex);
+            optionGroups.Add(trapGroup);
+
+            // Add logic to prevent minimum > maximum and vice versa
+            trapMinUpDown.OnChange += () =>
+            {
+                if (trapMinUpDown.GetValueInt() > trapMaxUpDown.GetValueInt())
+                {
+                    trapMaxUpDown.SetValueInt(trapMinUpDown.GetValueInt());
+                }
+            };
+            trapMaxUpDown.OnChange += () =>
+            {
+                if (trapMaxUpDown.GetValueInt() < trapMinUpDown.GetValueInt())
+                {
+                    trapMinUpDown.SetValueInt(trapMaxUpDown.GetValueInt());
+                }
+            };
         }
 
         public void PopulateDownpourTab()
@@ -332,7 +357,8 @@ namespace RainWorldRandomizer
 
             OpListBox listBox = new(RandoOptions.useFoodQuestChecks, new(LEFT_OPTION_X, runningY), 125f,
                 ["Disabled", "Enabled", "Gourmand Only"], 3, false);
-            OpLabel foodQuestLabel = new(LEFT_OPTION_X + 135f, runningY, Translate(RandoOptions.useFoodQuestChecks.info.Tags[0] as string));
+            OpLabel foodQuestLabel = new(LEFT_OPTION_X + 135f, runningY, Translate(RandoOptions.useFoodQuestChecks.info.Tags[0] as string))
+            { bumpBehav = listBox.bumpBehav };
             checksGroup.AddElements(listBox, foodQuestLabel);
             runningY -= NEWLINE_DECREMENT;
             checksGroup.AddCheckBox(RandoOptions.useExpandedFoodQuestChecks, new(LEFT_OPTION_X, runningY));
@@ -409,14 +435,6 @@ namespace RainWorldRandomizer
             deathLinkGroup.AddToTab(tabIndex);
             optionGroups.Add(deathLinkGroup);
 
-            OptionGroup trapGroup = new(this, "AP_Traps", new(10f, 10f), new(GROUP_SIZE_X - 30f, 0f));
-            OpUpdown trapMinUpDown = trapGroup.AddUpDown(RandoOptions.trapMinimumCooldown, true, new(RIGHT_OPTION_X + 30f, runningY), 60f);
-            runningY -= NEWLINE_DECREMENT;
-            OpUpdown trapMaxUpDown = trapGroup.AddUpDown(RandoOptions.trapMaximumCooldown, true, new(RIGHT_OPTION_X + 30f, runningY), 60f);
-            runningY -= NEWLINE_DECREMENT;
-            trapGroup.AddToTab(tabIndex);
-            optionGroups.Add(trapGroup);
-
             // Slot data information
             runningY = Mathf.Min(runningY, 322.5f);
             OptionGroup slotDataGroup = new(this, "AP_Slot_Data", new(10f, 10f), new(GROUP_SIZE_X, runningY - 60f));
@@ -447,7 +465,6 @@ namespace RainWorldRandomizer
                 }
                 connectionGroup.Disabled = APDisabled;
                 deathLinkGroup.Disabled = APDisabled;
-                trapGroup.Disabled = APDisabled;
                 foreach (OptionGroup group in standaloneExclusiveGroups)
                 {
                     group.Disabled = !APDisabled;
@@ -519,22 +536,6 @@ namespace RainWorldRandomizer
             {
                 // TODO: DeathLink probably shouldn't send a toggle to server every time the box is clicked, change to happen on apply settings
                 DeathLinkHandler.Active = deathLinkOverrideCheckbox.GetValueBool();
-            };
-
-            // Add logic to prevent minimum > maximum and vice versa
-            trapMinUpDown.OnChange += () =>
-            {
-                if (trapMinUpDown.GetValueInt() > trapMaxUpDown.GetValueInt())
-                {
-                    trapMaxUpDown.SetValueInt(trapMinUpDown.GetValueInt());
-                }
-            };
-            trapMaxUpDown.OnChange += () =>
-            {
-                if (trapMaxUpDown.GetValueInt() < trapMinUpDown.GetValueInt())
-                {
-                    trapMinUpDown.SetValueInt(trapMaxUpDown.GetValueInt());
-                }
             };
 
             clearSavesButton.OnClick += AskToClearSaveFiles;

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -70,10 +70,6 @@ namespace RainWorldRandomizer
                 new ConfigurableInfo("Include checks for eating karma flowers spawned in fixed locations", null, "",
                     ["Use Karma Flowers as checks"]));
 
-            RandoOptions.giveItemUnlocks = config.Bind<bool>("giveItemUnlocks", true,
-                new ConfigurableInfo("Whether random objects will be used as filler items. If not, extra gate keys will be added instead", null, "",
-                    ["Use random objects as filler"]));
-
             RandoOptions.itemShelterDelivery = config.Bind<bool>("itemShelterDelivery", false,
                 new ConfigurableInfo("Whether objects should be delivered in the next shelter instead of placed inside slugcat's stomach", null, "",
                     ["Deliver items in shelters"]));
@@ -276,8 +272,6 @@ namespace RainWorldRandomizer
 
             // Filler Items
             OptionGroup fillerGroup = new(this, "Filler_Items", new(10f, 10f), new(GROUP_SIZE_X, 0f));
-            fillerGroup.AddCheckBox(RandoOptions.giveItemUnlocks, new(LEFT_OPTION_X, runningY));
-            runningY -= NEWLINE_DECREMENT;
             fillerGroup.AddCheckBox(RandoOptions.givePassageUnlocks, new(LEFT_OPTION_X, runningY));
             runningY -= NEWLINE_DECREMENT;
             fillerGroup.AddUpDown(RandoOptions.hunterCyclesDensity, false, new(LEFT_OPTION_X, runningY), 60f);

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -79,10 +79,15 @@ namespace RainWorldRandomizer
                     ["Use Passage tokens as filler"]));
 
             RandoOptions.hunterCyclesDensity = config.Bind<float>("hunterCyclesDensity", 0.2f,
-                new ConfigurableInfo("The percentage amount of filler items that will be cycle increases when playing as Hunter (1 is 100%)." +
+                new ConfigurableInfo("The percentage amount of filler items that will increase the remaining cycles when playing as Hunter." +
                     "\nThe number of cycles each item gives is determined by 'Hunter Bonus Cycles' in Remix",
                     new ConfigAcceptableRange<float>(0, 1), "",
                     ["Hunter cycle increases"]));
+
+            RandoOptions.trapsDensity = config.Bind<float>("trapsDensity", 0.2f,
+                new ConfigurableInfo("The percentage amount of filler items that will be trap effects. Set to 0 to disable traps entirely",
+                    new ConfigAcceptableRange<float>(0, 1), "",
+                    ["Traps percentage"]));
 
             RandoOptions.randomizeSpawnLocation = config.Bind<bool>("randomizeSpawnLocation", false,
                 new ConfigurableInfo("Enables Expedition-like random starting location", null, "",
@@ -275,6 +280,8 @@ namespace RainWorldRandomizer
             fillerGroup.AddCheckBox(RandoOptions.givePassageUnlocks, new(LEFT_OPTION_X, runningY));
             runningY -= NEWLINE_DECREMENT;
             fillerGroup.AddUpDown(RandoOptions.hunterCyclesDensity, false, new(LEFT_OPTION_X, runningY), 60f);
+            runningY -= NEWLINE_DECREMENT;
+            fillerGroup.AddUpDown(RandoOptions.trapsDensity, false, new(LEFT_OPTION_X, runningY), 60f);
             fillerGroup.AddToTab(tabIndex);
             optionGroups.Add(fillerGroup);
 

--- a/Menu/SpoilerMenu.cs
+++ b/Menu/SpoilerMenu.cs
@@ -444,8 +444,8 @@ namespace RainWorldRandomizer
                 ,
                 EntrySortType.ItemName => (x, y) =>
                 {
-                    string xStr = x.ShowItem ? x.item.ID : null;
-                    string yStr = y.ShowItem ? y.item.ID : null;
+                    string xStr = x.ShowItem ? x.item.ToString() : null;
+                    string yStr = y.ShowItem ? y.item.ToString() : null;
                     return string.Compare(xStr, yStr);
                 }
                 ,
@@ -808,6 +808,11 @@ namespace RainWorldRandomizer
                         iconData = new IconSymbol.IconSymbolData(CreatureTemplate.Type.StandardGroundCreature, AbstractPhysicalObject.AbstractObjectType.DataPearl, 0);
                         spriteName = ItemSymbol.SpriteNameForItem(iconData.itemType, iconData.intData);
                         spriteColor = ItemSymbol.ColorForItem(iconData.itemType, iconData.intData);
+                        break;
+                    case "Trap":
+                        spriteName = "smallKarmaNoRing0";
+                        spriteColor = Color.red;
+                        spriteScale = 0.75f;
                         break;
                     case "HunterCycles":
                         iconData = new IconSymbol.IconSymbolData(CreatureTemplate.Type.Slugcat, AbstractPhysicalObject.AbstractObjectType.Creature, 0);

--- a/RandoOptions.cs
+++ b/RandoOptions.cs
@@ -20,6 +20,7 @@ namespace RainWorldRandomizer
         internal static Configurable<bool> itemShelterDelivery;
         internal static Configurable<bool> givePassageUnlocks;
         internal static Configurable<float> hunterCyclesDensity;
+        internal static Configurable<float> trapsDensity;
 
         internal static Configurable<bool> randomizeSpawnLocation;
         internal static Configurable<bool> startMinKarma;
@@ -86,6 +87,8 @@ namespace RainWorldRandomizer
             || Plugin.RandoManager is ManagerArchipelago;
 
         public static float HunterCycleIncreaseDensity => hunterCyclesDensity.Value;
+
+        public static float TrapsDensity => trapsDensity.Value;
 
         public static bool RandomizeSpawnLocation => Plugin.RandoManager is ManagerArchipelago
             ? ArchipelagoConnection.useRandomStart : randomizeSpawnLocation.Value;

--- a/RandoOptions.cs
+++ b/RandoOptions.cs
@@ -17,7 +17,6 @@ namespace RainWorldRandomizer
         internal static Configurable<bool> useDevTokenChecks;
         internal static Configurable<bool> useKarmaFlowerChecks;
 
-        internal static Configurable<bool> giveItemUnlocks;
         internal static Configurable<bool> itemShelterDelivery;
         internal static Configurable<bool> givePassageUnlocks;
         internal static Configurable<float> hunterCyclesDensity;
@@ -79,9 +78,6 @@ namespace RainWorldRandomizer
 
         public static bool UseKarmaFlowerChecks => Plugin.RandoManager is ManagerArchipelago
             ? ArchipelagoConnection.flowersanity : useKarmaFlowerChecks.Value;
-
-        public static bool GiveObjectItems => giveItemUnlocks.Value
-            || Plugin.RandoManager is ManagerArchipelago;
 
         public static bool ItemShelterDelivery => itemShelterDelivery.Value
             || (ModManager.MSC && Plugin.RandoManager.currentSlugcat == MoreSlugcatsEnums.SlugcatStatsName.Spear);

--- a/Unlock.cs
+++ b/Unlock.cs
@@ -39,23 +39,6 @@ namespace RainWorldRandomizer
             { "VultureMask", "Vulture Mask" },
         };
 
-        public static Dictionary<Item, int> junkItems = new()
-        {
-            { new Item("Spear", AbstractPhysicalObject.AbstractObjectType.Spear), 20 },
-            { IDToItem("FireSpear"), 12 },
-            { new Item("Bomb", AbstractPhysicalObject.AbstractObjectType.ScavengerBomb), 15 },
-            { new Item("Spore Puff", AbstractPhysicalObject.AbstractObjectType.PuffBall), 7 },
-            { new Item("Mushroom", AbstractPhysicalObject.AbstractObjectType.Mushroom), 7 },
-            { new Item("Bubble Weed", AbstractPhysicalObject.AbstractObjectType.BubbleGrass), 7 },
-            { new Item("Lantern", AbstractPhysicalObject.AbstractObjectType.Lantern), 5 },
-            { new Item("Pearl", AbstractPhysicalObject.AbstractObjectType.DataPearl), 5 },
-            { new Item("Karma Flower", AbstractPhysicalObject.AbstractObjectType.KarmaFlower), 5 },
-            { new Item("Vulture Mask", AbstractPhysicalObject.AbstractObjectType.VultureMask), 3 }
-        };
-
-        // MSC exclusive
-        public static Dictionary<Item, int> junkItemsMSC;
-
         public static bool hasSeenItemTutorial = false;
 
         public string ID { get; set; }
@@ -72,6 +55,7 @@ namespace RainWorldRandomizer
             public static readonly UnlockType Mark = new("The_Mark", true);
             public static readonly UnlockType Item = new("Item", true);
             public static readonly UnlockType ItemPearl = new("ItemPearl", true);
+            public static readonly UnlockType Trap = new("Trap", true);
             public static readonly UnlockType HunterCycles = new("HunterCycles", true);
             public static readonly UnlockType IdDrone = new("IdDrone", true);
             public static readonly UnlockType DisconnectFP = new("DisconnectFP", true);
@@ -163,6 +147,9 @@ namespace RainWorldRandomizer
                     }
                     ShowItemTutorial();
                     break;
+                case "Trap":
+                    TrapsHandler.EnqueueTrap(ID);
+                    break;
                 case "HunterCycles":
                     Plugin.RandoManager.HunterBonusCyclesGiven++;
                     break;
@@ -191,44 +178,13 @@ namespace RainWorldRandomizer
                 "Neuron_Glow" => "Unlocked Neuron Glow",
                 "The_Mark" => "Unlocked The Mark",
                 "Item" => $"Found {ItemToEncodedIcon((Item)item)}",
+                "Trap" => $"Found a trap!",
                 "HunterCycles" => "Increased Lifespan",
                 "IdDrone" => "Found Citizen ID Drone",
                 "DisconnectFP" => "Disconnected Five Pebbles",
                 "RewriteSpearPearl" => "Unlocked Broadcast Encoding",
                 _ => $"Unlocked {ID}",
             };
-        }
-
-        public static Item RandomJunkItem()
-        {
-            List<Item> items = junkItems.Keys.ToList();
-            List<int> weights = junkItems.Values.ToList();
-
-            if (ModManager.MSC)
-            {
-                junkItemsMSC ??= new Dictionary<Item, int>()
-                {
-                    { IDToItem("ElectricSpear"), 3 },
-                    { new Item("Singularity Bomb", DLCSharedEnums.AbstractObjectType.SingularityBomb), 1 }
-                };
-                items.AddRange(junkItemsMSC.Keys);
-                weights.AddRange(junkItemsMSC.Values);
-            }
-
-            int sum = weights.Sum();
-            int randomValue = UnityEngine.Random.Range(0, sum + 1);
-
-            int cursor = 0;
-            for (int i = 0; i < items.Count; i++)
-            {
-                cursor += weights[i];
-                if (cursor >= randomValue)
-                {
-                    return items[i];
-                }
-            }
-
-            return new Item();
         }
 
         public override string ToString()
@@ -241,6 +197,7 @@ namespace RainWorldRandomizer
                 "Neuron_Glow" => "Neuron Glow",
                 "The_Mark" => "The Mark",
                 "Item" => item.Value.name,
+                "Trap" => ID[5..],
                 "HunterCycles" => $"+{(ModManager.MMF ? MoreSlugcats.MMF.cfgHunterBonusCycles.Value : "5")} Cycles",
                 "IdDrone" => "Citizen ID Drone",
                 "DisconnectFP" => "Disconnect Pebbles",


### PR DESCRIPTION
Traps are finally implemented in standalone, with a configurable percentage of filler items to take up. Trap cooldown options have been moved to the base tab as they now apply to both modes.

Removed the option to disable object filler. The alternative, duplicating gates, isn't interesting and the objects don't really have a downside to warrant disabling them. (I mainly did this to clear up space on the option page for trap percentage)

Closes #5 

