### PR TITLE
Tweak item queue and save system

### DIFF
--- a/Archipelago/ArchipelagoConnection.cs
+++ b/Archipelago/ArchipelagoConnection.cs
@@ -3,7 +3,6 @@ using Archipelago.MultiClient.Net.Colors;
 using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.MessageLog.Messages;
 using Archipelago.MultiClient.Net.Packets;
-using MoreSlugcats;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -246,7 +245,7 @@ namespace RainWorldRandomizer
             CurrentlyConnecting = false;
             ReceivedSlotData = false;
 
-            if (resetManager) (Plugin.RandoManager as ManagerArchipelago).Reset();
+            if (resetManager) Plugin.RandoManager = null; //(Plugin.RandoManager as ManagerArchipelago).Reset();
 
             return true;
         }
@@ -418,11 +417,11 @@ namespace RainWorldRandomizer
 
             DeathLinkHandler.Active = deathLink > 0;
 
-            foodQuest = IsMSC && 
-                (Slugcat.value == "Gourmand" || foodQuestAccess == 2) 
-                ? (foodQuestAccessibility > 0 
-                    ? FoodQuestBehavior.Expanded 
-                    : FoodQuestBehavior.Enabled) 
+            foodQuest = IsMSC &&
+                (Slugcat.value == "Gourmand" || foodQuestAccess == 2)
+                ? (foodQuestAccessibility > 0
+                    ? FoodQuestBehavior.Expanded
+                    : FoodQuestBehavior.Enabled)
                 : FoodQuestBehavior.Disabled;
             ArchipelagoConnection.foodQuestAccessibility = foodQuestAccessibility;
 

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -63,7 +63,7 @@ namespace RainWorldRandomizer
         public void Reset()
         {
             // Reset all tracking variables
-            _currentMaxKarma = 4;
+            _currentMaxKarma = 0;
             _hunterBonusCyclesGiven = 0;
             _givenNeuronGlow = false;
             _givenMark = false;
@@ -141,9 +141,11 @@ namespace RainWorldRandomizer
                 locationsStatus.Add(GetLocStringIDFromID(loc), false);
             }
             Plugin.Log.LogInfo($"Found no saved game, creating new save");
-            SaveManager.WriteAPSaveToFile(saveId, ArchipelagoConnection.lastItemIndex, locationsStatus);
+            //SaveManager.WriteAPSaveToFile(saveId, ArchipelagoConnection.lastItemIndex, locationsStatus);
 
             locationsLoaded = true;
+
+            SaveGame(false);
         }
 
         public void InitNewInventory(List<string> newItems)
@@ -323,10 +325,10 @@ namespace RainWorldRandomizer
 
         public override void SaveGame(bool saveCurrentState)
         {
-                SaveManager.WriteItemQueueToFile(
+            SaveManager.WriteItemQueueToFile(
                 saveCurrentState ? itemDeliveryQueue : lastItemDeliveryQueue,
-                    currentSlugcat,
-                    Plugin.Singleton.rainWorld.options.saveSlot);
+                currentSlugcat,
+                Plugin.Singleton.rainWorld.options.saveSlot);
 
             // Don't save if locations are not loaded
             if (!locationsLoaded) return;

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace RainWorldRandomizer
 {
@@ -79,6 +78,7 @@ namespace RainWorldRandomizer
             passageTokensStatus.Clear();
             itemDeliveryQueue.Clear();
             lastItemDeliveryQueue.Clear();
+            pendingTrapQueue.Clear();
 
             // Clear notifications
             Plugin.Singleton.notifQueue.Clear();
@@ -118,7 +118,7 @@ namespace RainWorldRandomizer
             }
 
             // Load the item delivery queue from file as normal
-            itemDeliveryQueue = SaveManager.LoadItemQueue(ArchipelagoConnection.Slugcat, Plugin.Singleton.rainWorld.options.saveSlot);
+            (itemDeliveryQueue, pendingTrapQueue) = SaveManager.LoadItemQueue(ArchipelagoConnection.Slugcat, Plugin.Singleton.rainWorld.options.saveSlot);
             lastItemDeliveryQueue = new(itemDeliveryQueue);
 
             Plugin.Log.LogInfo($"Loaded save game {saveId}");
@@ -327,6 +327,7 @@ namespace RainWorldRandomizer
         {
             SaveManager.WriteItemQueueToFile(
                 saveCurrentState ? itemDeliveryQueue : lastItemDeliveryQueue,
+                pendingTrapQueue,
                 currentSlugcat,
                 Plugin.Singleton.rainWorld.options.saveSlot);
 

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -77,8 +77,8 @@ namespace RainWorldRandomizer
             // Reset unlock lists
             gatesStatus.Clear();
             passageTokensStatus.Clear();
-            Plugin.Singleton.itemDeliveryQueue.Clear();
-            Plugin.Singleton.lastItemDeliveryQueue.Clear();
+            itemDeliveryQueue.Clear();
+            lastItemDeliveryQueue.Clear();
 
             // Clear notifications
             Plugin.Singleton.notifQueue.Clear();
@@ -118,8 +118,8 @@ namespace RainWorldRandomizer
             }
 
             // Load the item delivery queue from file as normal
-            Plugin.Singleton.itemDeliveryQueue = SaveManager.LoadItemQueue(ArchipelagoConnection.Slugcat, Plugin.Singleton.rainWorld.options.saveSlot);
-            Plugin.Singleton.lastItemDeliveryQueue = new Queue<Unlock.Item>(Plugin.Singleton.itemDeliveryQueue);
+            itemDeliveryQueue = SaveManager.LoadItemQueue(ArchipelagoConnection.Slugcat, Plugin.Singleton.rainWorld.options.saveSlot);
+            lastItemDeliveryQueue = new(itemDeliveryQueue);
 
             Plugin.Log.LogInfo($"Loaded save game {saveId}");
             locationsLoaded = true;
@@ -323,13 +323,10 @@ namespace RainWorldRandomizer
 
         public override void SaveGame(bool saveCurrentState)
         {
-            if (saveCurrentState)
-            {
                 SaveManager.WriteItemQueueToFile(
-                    Plugin.Singleton.itemDeliveryQueue,
+                saveCurrentState ? itemDeliveryQueue : lastItemDeliveryQueue,
                     currentSlugcat,
                     Plugin.Singleton.rainWorld.options.saveSlot);
-            }
 
             // Don't save if locations are not loaded
             if (!locationsLoaded) return;

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -83,7 +83,8 @@ namespace RainWorldRandomizer
 
             if (ID == ProcessManager.ProcessID.MainMenu)
             {
-                // Turn off randomizer when quitting to menu
+                // Vanilla manager does not exist outside of the scope of gameplay. TODO: Eventually, neither will any other manager
+                if (Plugin.RandoManager is ManagerVanilla) Plugin.RandoManager = null;
                 if (Plugin.RandoManager is not null) Plugin.RandoManager.isRandomizerActive = false;
             }
 
@@ -193,7 +194,7 @@ namespace RainWorldRandomizer
             {
                 // Spawn pending items in spawn room
                 if (!RandoOptions.ItemShelterDelivery) return;
-                
+
                 while (Plugin.RandoManager.itemDeliveryQueue.Count > 0)
                 {
                     AbstractPhysicalObject obj = Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Dequeue(), self.world, self.world.GetAbstractRoom(roomIndex));

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -384,14 +384,14 @@ namespace RainWorldRandomizer
 
         private static void SaveDiskUpdateItemQueue(bool completeCycle, bool malnourished)
         {
-            // If we survived this cycle, paste current queue to saved backup
-            // If we died, restore current queue from saved backup
+            // If we did not finish the cycle (death, quit out, etc.), restore current queue from saved backup
             if (!completeCycle)
             {
                 Plugin.RandoManager.itemDeliveryQueue = new(Plugin.RandoManager.lastItemDeliveryQueue);
                 return;
             }
 
+            // If we survived without starving this cycle, paste current queue to saved backup
             if (!malnourished)
             {
                 Plugin.RandoManager.lastItemDeliveryQueue = new(Plugin.RandoManager.itemDeliveryQueue);

--- a/Hooks/PlayerHooks.cs
+++ b/Hooks/PlayerHooks.cs
@@ -43,7 +43,7 @@ namespace RainWorldRandomizer
         {
             if (!Plugin.RandoManager.isRandomizerActive
                 || RandoOptions.ItemShelterDelivery
-                || Plugin.Singleton.itemDeliveryQueue.Count == 0)
+                || Plugin.RandoManager.itemDeliveryQueue.Count == 0)
             {
                 orig(self);
                 return;
@@ -59,7 +59,7 @@ namespace RainWorldRandomizer
             // Swap in queued object
 
             //Logger.LogDebug($"Stored item: {itemDeliveryQueue.Peek().id}, {itemDeliveryQueue.Peek().type.value}");
-            self.objectInStomach = Plugin.ItemToAbstractObject(Plugin.Singleton.itemDeliveryQueue.Dequeue(), self.room);
+            self.objectInStomach = Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Dequeue(), self.room);
             //Logger.LogDebug($"Converted object: {self.objectInStomach?.type}");
 
             orig(self);
@@ -109,9 +109,9 @@ namespace RainWorldRandomizer
                 {
                     return objectInstomach;
                 }
-                if (!RandoOptions.ItemShelterDelivery && Plugin.Singleton.itemDeliveryQueue.Count > 0)
+                if (!RandoOptions.ItemShelterDelivery && Plugin.RandoManager.itemDeliveryQueue.Count > 0)
                 {
-                    return Plugin.ItemToAbstractObject(Plugin.Singleton.itemDeliveryQueue.Peek(), player.room);
+                    return Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Peek(), player.room);
                 }
 
                 return null;
@@ -151,7 +151,7 @@ namespace RainWorldRandomizer
 
             c.EmitDelegate<Func<int, int>>((origTime) =>
             {
-                if (!RandoOptions.ItemShelterDelivery && Plugin.Singleton.itemDeliveryQueue.Count > 0)
+                if (!RandoOptions.ItemShelterDelivery && Plugin.RandoManager.itemDeliveryQueue.Count > 0)
                 {
                     // This time needs to be longer than the 90 ticks swallowing an item takes
                     return 95;
@@ -184,9 +184,9 @@ namespace RainWorldRandomizer
                 {
                     return objectInstomach;
                 }
-                if (!RandoOptions.ItemShelterDelivery && Plugin.Singleton.itemDeliveryQueue.Count > 0)
+                if (!RandoOptions.ItemShelterDelivery && Plugin.RandoManager.itemDeliveryQueue.Count > 0)
                 {
-                    return Plugin.ItemToAbstractObject(Plugin.Singleton.itemDeliveryQueue.Peek(), playerGraphics.player.room);
+                    return Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Peek(), playerGraphics.player.room);
                 }
 
                 return null;

--- a/Hooks/PlayerHooks.cs
+++ b/Hooks/PlayerHooks.cs
@@ -219,6 +219,8 @@ namespace RainWorldRandomizer
         {
             int origResult = orig(extracycles);
 
+            if (Plugin.RandoManager is null) return int.MaxValue;
+
             // Remove cycle limit completely for Archipelago
             if (Plugin.RandoManager is ManagerArchipelago)
             {
@@ -236,16 +238,16 @@ namespace RainWorldRandomizer
             int baseCycles = extracycles ? origResult - bonusCycles : origResult;
 
             // If the save hasn't been initialized, read the file to count cycles
-            if (!Plugin.RandoManager.isRandomizerActive)
-            {
-                int countedCycles = SaveManager.CountRedsCycles(Plugin.Singleton.rainWorld.options.saveSlot);
-                if (countedCycles == -1)
-                {
-                    return origResult;
-                }
+            //if (!Plugin.RandoManager.isRandomizerActive)
+            //{
+            //    int countedCycles = SaveManager.CountRedsCycles(Plugin.Singleton.rainWorld.options.saveSlot);
+            //    if (countedCycles == -1)
+            //    {
+            //        return origResult;
+            //    }
 
-                return baseCycles + (countedCycles * bonusCycles);
-            }
+            //    return baseCycles + (countedCycles * bonusCycles);
+            //}
 
             return baseCycles + (Plugin.RandoManager.HunterBonusCyclesGiven * bonusCycles);
         }

--- a/ManagerBase.cs
+++ b/ManagerBase.cs
@@ -20,6 +20,7 @@ namespace RainWorldRandomizer
         // Queue of items that the player has recieved and not claimed
         public Queue<Unlock.Item> itemDeliveryQueue = new();
         public Queue<Unlock.Item> lastItemDeliveryQueue = new();
+        public Queue<TrapsHandler.Trap> pendingTrapQueue = new();
 
         // These are all properties so the get / set can be modified if needed
         public virtual int CurrentMaxKarma

--- a/ManagerBase.cs
+++ b/ManagerBase.cs
@@ -17,6 +17,9 @@ namespace RainWorldRandomizer
         /// </summary>
         protected Dictionary<string, bool> gatesStatus = [];
         protected Dictionary<WinState.EndgameID, bool> passageTokensStatus = [];
+        // Queue of items that the player has recieved and not claimed
+        public Queue<Unlock.Item> itemDeliveryQueue = new();
+        public Queue<Unlock.Item> lastItemDeliveryQueue = new();
 
         // These are all properties so the get / set can be modified if needed
         public virtual int CurrentMaxKarma

--- a/ManagerVanilla.cs
+++ b/ManagerVanilla.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -237,8 +236,8 @@ namespace RainWorldRandomizer
                 }
             }
 
-            Plugin.RandoManager.itemDeliveryQueue = SaveManager.LoadItemQueue(slugcat, saveSlot);
-            Plugin.RandoManager.lastItemDeliveryQueue = new(Plugin.RandoManager.itemDeliveryQueue);
+            (itemDeliveryQueue, pendingTrapQueue) = SaveManager.LoadItemQueue(slugcat, saveSlot);
+            lastItemDeliveryQueue = new(Plugin.RandoManager.itemDeliveryQueue);
         }
 
         public override List<string> GetLocations()
@@ -279,12 +278,13 @@ namespace RainWorldRandomizer
         public override void SaveGame(bool saveCurrentState)
         {
             SaveManager.WriteSavedGameToFile(
-                        randomizerKey,
-                        currentSlugcat,
-                        Plugin.Singleton.rainWorld.options.saveSlot);
+                randomizerKey,
+                currentSlugcat,
+                Plugin.Singleton.rainWorld.options.saveSlot);
 
             SaveManager.WriteItemQueueToFile(
                 saveCurrentState ? itemDeliveryQueue : lastItemDeliveryQueue,
+                pendingTrapQueue,
                 currentSlugcat,
                 Plugin.Singleton.rainWorld.options.saveSlot);
         }

--- a/ManagerVanilla.cs
+++ b/ManagerVanilla.cs
@@ -235,11 +235,10 @@ namespace RainWorldRandomizer
                         if (item.IsGiven) _givenSpearPearlRewrite = true;
                         break;
                 }
-
             }
 
-            Plugin.Singleton.itemDeliveryQueue = SaveManager.LoadItemQueue(slugcat, saveSlot);
-            Plugin.Singleton.lastItemDeliveryQueue = new Queue<Unlock.Item>(Plugin.Singleton.itemDeliveryQueue);
+            Plugin.RandoManager.itemDeliveryQueue = SaveManager.LoadItemQueue(slugcat, saveSlot);
+            Plugin.RandoManager.lastItemDeliveryQueue = new(Plugin.RandoManager.itemDeliveryQueue);
         }
 
         public override List<string> GetLocations()
@@ -284,13 +283,10 @@ namespace RainWorldRandomizer
                         currentSlugcat,
                         Plugin.Singleton.rainWorld.options.saveSlot);
 
-            if (saveCurrentState)
-            {
-                SaveManager.WriteItemQueueToFile(
-                    Plugin.Singleton.itemDeliveryQueue,
-                    currentSlugcat,
-                    Plugin.Singleton.rainWorld.options.saveSlot);
-            }
+            SaveManager.WriteItemQueueToFile(
+                saveCurrentState ? itemDeliveryQueue : lastItemDeliveryQueue,
+                currentSlugcat,
+                Plugin.Singleton.rainWorld.options.saveSlot);
         }
     }
 }

--- a/Menu/MenuExtension.cs
+++ b/Menu/MenuExtension.cs
@@ -77,7 +77,7 @@ namespace RainWorldRandomizer
 
             self.pages[0].subObjects.Add(gateDisplay);
 
-            if (Plugin.Singleton.itemDeliveryQueue.Count > 0)
+            if (Plugin.RandoManager.itemDeliveryQueue.Count > 0)
             {
                 PendingItemsDisplay pendingItemsDisplay = new(self, self.pages[0],
                     new Vector2((1366f - manager.rainWorld.screenSize.x) / 2f + xOffset, manager.rainWorld.screenSize.y - gateDisplay.size.y - 20f));
@@ -199,7 +199,7 @@ namespace RainWorldRandomizer
 
         public PendingItemsDisplay(Menu.Menu menu, MenuObject owner, Vector2 pos) : base(menu, owner, pos, default)
         {
-            Unlock.Item[] pendingItems = [.. Plugin.Singleton.itemDeliveryQueue];
+            Unlock.Item[] pendingItems = [.. Plugin.RandoManager.itemDeliveryQueue];
             sprites = new FSprite[pendingItems.Length];
             size = new Vector2(250f, ((pendingItems.Length - 1) / 8 * 30f) + 57f);
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -46,9 +46,6 @@ namespace RainWorldRandomizer
 
         // Queue of pending notifications to be sent to the player in-game
         public Queue<ChatLog.MessageText> notifQueue = new();
-        // Queue of items that the player has recieved and not claimed
-        public Queue<Unlock.Item> lastItemDeliveryQueue = new();
-        public Queue<Unlock.Item> itemDeliveryQueue = new();
 
         // A map of every region to it's display name
         public static Dictionary<string, string> RegionNamesMap = [];

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -90,7 +90,6 @@ namespace RainWorldRandomizer
             }
 
             // Assign as vanilla until decided otherwise
-            RandoManager = new ManagerVanilla();
             collectTokenHandler = new CollectTokenHandler();
             Log = Logger;
 

--- a/SaveManager.cs
+++ b/SaveManager.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -10,13 +11,7 @@ namespace RainWorldRandomizer
     {
         public static bool IsThereASavedGame(SlugcatStats.Name slugcat, int saveSlot)
         {
-            return File.Exists(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.txt"))
-                || IsThereALegacySavedGame(slugcat, saveSlot);
-        }
-
-        public static bool IsThereALegacySavedGame(SlugcatStats.Name slugcat, int saveSlot)
-        {
-            return File.Exists(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.json"));
+            return File.Exists(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.txt"));
         }
 
         // Meant for vanilla saves only
@@ -36,23 +31,12 @@ namespace RainWorldRandomizer
             }
 
             file.Close();
-
-            // If this game was loaded from a legacy save, delete it now
-            if (IsThereALegacySavedGame(slugcat, saveSlot))
-            {
-                File.Delete(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.json"));
-            }
         }
 
         // Meant for vanilla saves only
         public static Dictionary<string, Unlock> LoadSavedGame(SlugcatStats.Name slugcat, int saveSlot)
         {
             Dictionary<string, Unlock> game = [];
-
-            if (IsThereALegacySavedGame(slugcat, saveSlot))
-            {
-                return DeserializeGameFromJson(slugcat, saveSlot);
-            }
 
             string[] file = File.ReadAllLines(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.txt"));
 
@@ -90,39 +74,6 @@ namespace RainWorldRandomizer
                 Unlock unlock = new(
                     type,
                     unlockString[1],
-                    bool.Parse(unlockString[2]));
-
-                game.Add(keyValue[0], unlock);
-            }
-
-            return game;
-        }
-
-        // Load game from legacy .json format
-        private static Dictionary<string, Unlock> DeserializeGameFromJson(SlugcatStats.Name slugcat, int saveSlot)
-        {
-            Dictionary<string, Unlock> game = [];
-
-            string[] json = File.ReadAllLines(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"saved_game_{slugcat.value}_{saveSlot}.json"));
-
-            foreach (string line in json)
-            {
-                string[] keyValue = Regex.Split(line
-                    .Replace("\\u0022", "")
-                    .TrimStart("[\"".ToCharArray())
-                    .TrimEnd("\"]".ToCharArray()), "\",\"");
-
-                string[] unlockString = keyValue[1]
-                    .Replace("ID:", "")
-                    .Replace("IsGiven:", "")
-                    .Replace("Type:", "")
-                    .TrimStart('{')
-                    .TrimEnd('}')
-                    .Split(',');
-
-                Unlock unlock = new Unlock(
-                    Unlock.UnlockType.typeOrder[int.Parse(unlockString[1])],
-                    unlockString[0],
                     bool.Parse(unlockString[2]));
 
                 game.Add(keyValue[0], unlock);
@@ -172,12 +123,10 @@ namespace RainWorldRandomizer
                 if (itemString[0] == nameof(DataPearl.AbstractDataPearl.DataPearlType))
                 {
                     item = Unlock.IDToItem(itemString[1], true);
-                    //item = new Unlock.Item(itemString[2], new DataPearl.AbstractDataPearl.DataPearlType(itemString[1]));
                 }
                 else if (itemString[0] == nameof(AbstractPhysicalObject.AbstractObjectType))
                 {
                     item = Unlock.IDToItem(itemString[1]);
-                    //item = new Unlock.Item(itemString[2], new AbstractPhysicalObject.AbstractObjectType(itemString[1]));
                 }
                 else
                 {
@@ -185,17 +134,13 @@ namespace RainWorldRandomizer
                     continue;
                 }
 
-                //if (itemString.Length >= 4)
-                //{
-                //    item.id = itemString[3];
-                //}
-
                 itemQueue.Enqueue(item);
             }
 
             return itemQueue;
         }
 
+        [Obsolete("Unsafe when RandoManager is null, which is the only case where it is useful")]
         public static int CountRedsCycles(int saveSlot)
         {
             if (!IsThereASavedGame(SlugcatStats.Name.Red, saveSlot))
@@ -207,81 +152,7 @@ namespace RainWorldRandomizer
             return game.Values.Where(u => u.Type == Unlock.UnlockType.HunterCycles && u.IsGiven).Count();
         }
 
-        #region Archipelago saved data
-        // Fetch locally saved checksum
-        /*
-        public static string GetDataPackageChecksum()
-        {
-            string path = Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_checksum.txt");
-            if (!File.Exists(path))
-            {
-                return "";
-            }
-
-            string[] file = File.ReadAllLines(path);
-
-            return file.Length > 0 ? file[0] : "";
-        }
-        
-        public static void WriteDataPackageToFile(Dictionary<string, long> itemLookup, Dictionary<string, long> locationLookup, string checksum)
-        {
-            Plugin.Log.LogDebug("Writing Data package files...");
-            StreamWriter itemsFile = File.CreateText(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_items.txt"));
-
-            foreach (var item in itemLookup)
-            {
-                itemsFile.Write($"{item.Key}->{item.Value}");
-                itemsFile.WriteLine();
-            }
-            itemsFile.Close();
-
-            StreamWriter locationsFile = File.CreateText(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_locations.txt"));
-
-            foreach (var item in locationLookup)
-            {
-                locationsFile.Write($"{item.Key}->{item.Value}");
-                locationsFile.WriteLine();
-            }
-            locationsFile.Close();
-
-            StreamWriter checksumFile = File.CreateText(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_checksum.txt"));
-            checksumFile.Write(checksum);
-            checksumFile.Close();
-
-            Plugin.Log.LogDebug("DataPackage file write complete");
-        }
-
-        public static bool LoadDataPackage(out Dictionary<string, long> itemLookup, out Dictionary<string, long> locationLookup)
-        {
-            itemLookup = new Dictionary<string, long>();
-            locationLookup = new Dictionary<string, long>();
-
-            string itemsPath = Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_items.txt");
-            string locationsPath = Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_datapackage_locations.txt");
-
-            if (!(File.Exists(itemsPath) && File.Exists(locationsPath)))
-            {
-                return false;
-            }
-
-            string[] itemsFile = File.ReadAllLines(itemsPath);
-            foreach (string line in itemsFile)
-            {
-                string[] keyValue = Regex.Split(line, "->");
-                itemLookup.Add(keyValue[0], long.Parse(keyValue[1]));
-            }
-
-            string[] locationsFile = File.ReadAllLines(locationsPath);
-            foreach (string line in locationsFile)
-            {
-                string[] keyValue = Regex.Split(line, "->");
-                locationLookup.Add(keyValue[0], long.Parse(keyValue[1]));
-            }
-
-            return true;
-        }
-        */
-
+        #region Archipelago save data
         public struct APSave(long lastIndex, Dictionary<string, bool> locationsStatus)
         {
             public long lastIndex = lastIndex;
@@ -336,36 +207,6 @@ namespace RainWorldRandomizer
                 }
             }
         }
-
-        public static void WriteLastItemIndexToFile(string saveId, long lastIndex)
-        {
-            Dictionary<string, long> origRegistry = LoadLastItemIndices();
-            if (origRegistry.ContainsKey(saveId))
-            {
-                origRegistry[saveId] = lastIndex;
-            }
-            else
-            {
-                origRegistry.Add(saveId, lastIndex);
-            }
-
-            StreamWriter indexFile = File.CreateText(Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_save_registry.txt"));
-
-            indexFile.Write(JsonConvert.SerializeObject(origRegistry));
-            indexFile.Close();
-        }
-
-        public static Dictionary<string, long> LoadLastItemIndices()
-        {
-            string path = Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, "ap_save_registry.txt");
-            if (!File.Exists(path))
-            {
-                return [];
-            }
-
-            return JsonConvert.DeserializeObject<Dictionary<string, long>>(File.ReadAllText(path)) ?? [];
-        }
-
         #endregion
     }
 }

--- a/TrapsHandler.cs
+++ b/TrapsHandler.cs
@@ -9,7 +9,7 @@ namespace RainWorldRandomizer
 {
     public static class TrapsHandler
     {
-        private class Trap
+        public class Trap
         {
             public string id;
             public TrapDefinition definition;
@@ -107,11 +107,6 @@ namespace RainWorldRandomizer
         };
 
         private static int currentCooldown = 0;
-        // TODO: Save pending traps like we do items
-        /// <summary>
-        /// Traps waiting to be activated
-        /// </summary>
-        private static Queue<Trap> pendingTrapQueue = new();
         /// <summary>
         /// Traps with a duration that are currently active
         /// </summary>
@@ -150,7 +145,7 @@ namespace RainWorldRandomizer
 
         public static void EnqueueTrap(string itemId)
         {
-            pendingTrapQueue.Enqueue(new Trap(itemId.Substring(5)));
+            Plugin.RandoManager?.pendingTrapQueue.Enqueue(new Trap(itemId[5..]));
         }
 
         private static void ResetCooldown()
@@ -172,7 +167,7 @@ namespace RainWorldRandomizer
 
             TrapUpdate(self);
 
-            if (pendingTrapQueue.Count == 0) return;
+            if ((Plugin.RandoManager?.pendingTrapQueue.Count ?? 0) == 0) return;
 
             if (currentCooldown == 0)
             {
@@ -186,7 +181,7 @@ namespace RainWorldRandomizer
                 }
 
                 // Process the next trap in queue
-                pendingTrapQueue.Dequeue().Activate(self);
+                Plugin.RandoManager.pendingTrapQueue.Dequeue().Activate(self);
 
                 ResetCooldown();
             }

--- a/Unlock.cs
+++ b/Unlock.cs
@@ -122,13 +122,13 @@ namespace RainWorldRandomizer
                 case "Item":
                     if (item != null)
                     {
-                        Plugin.Singleton.itemDeliveryQueue.Enqueue((Item)item);
-                        Plugin.Singleton.lastItemDeliveryQueue.Enqueue((Item)item);
+                        Plugin.RandoManager.itemDeliveryQueue.Enqueue((Item)item);
+                        Plugin.RandoManager.lastItemDeliveryQueue.Enqueue((Item)item);
                     }
                     else
                     {
-                        Plugin.Singleton.itemDeliveryQueue.Enqueue(IDToItem(ID));
-                        Plugin.Singleton.lastItemDeliveryQueue.Enqueue(IDToItem(ID));
+                        Plugin.RandoManager.itemDeliveryQueue.Enqueue(IDToItem(ID));
+                        Plugin.RandoManager.lastItemDeliveryQueue.Enqueue(IDToItem(ID));
                         item = IDToItem(ID);
                     }
                     ShowItemTutorial();
@@ -136,13 +136,13 @@ namespace RainWorldRandomizer
                 case "ItemPearl":
                     if (item != null)
                     {
-                        Plugin.Singleton.itemDeliveryQueue.Enqueue((Item)item);
-                        Plugin.Singleton.lastItemDeliveryQueue.Enqueue((Item)item);
+                        Plugin.RandoManager.itemDeliveryQueue.Enqueue((Item)item);
+                        Plugin.RandoManager.lastItemDeliveryQueue.Enqueue((Item)item);
                     }
                     else
                     {
-                        Plugin.Singleton.itemDeliveryQueue.Enqueue(IDToItem(ID, true));
-                        Plugin.Singleton.lastItemDeliveryQueue.Enqueue(IDToItem(ID, true));
+                        Plugin.RandoManager.itemDeliveryQueue.Enqueue(IDToItem(ID, true));
+                        Plugin.RandoManager.lastItemDeliveryQueue.Enqueue(IDToItem(ID, true));
                         item = IDToItem(ID, true);
                     }
                     ShowItemTutorial();


### PR DESCRIPTION
- Better defined the times at which the RandoManager should exist, and make it null when not in use.
- Item and trap delivery are now stored in the RandoManager for easier management (Closes #121)
- Clean up old SaveManager functions
- Save traps to file, untriggered ones will no longer be lost to the void when quitting out
