### PR TITLE
Deliver pending objects via menu

### DIFF
--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -9,6 +9,8 @@ namespace RainWorldRandomizer
 {
     public static class GameLoopHooks
     {
+        private const int SHELTER_ITEMS_PER_CYCLE = 5;
+
         public static void ApplyHooks()
         {
             On.ProcessManager.PostSwitchMainProcess += OnPostSwitchMainProcess;
@@ -199,8 +201,10 @@ namespace RainWorldRandomizer
                 // Spawn pending items in spawn room
                 if (!RandoOptions.ItemShelterDelivery) return;
 
-                while (Plugin.RandoManager.itemDeliveryQueue.Count > 0)
+                for (int i = 0; i < SHELTER_ITEMS_PER_CYCLE; i++)
                 {
+                    if (Plugin.RandoManager.itemDeliveryQueue.Count == 0) break;
+
                     AbstractPhysicalObject obj = Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Dequeue(), self.world, self.world.GetAbstractRoom(roomIndex));
                     try
                     {

--- a/Hooks/PlayerHooks.cs
+++ b/Hooks/PlayerHooks.cs
@@ -49,26 +49,8 @@ namespace RainWorldRandomizer
                 return;
             }
 
-            AbstractPhysicalObject tempObject = null;
-
-            // If there's already something swallowed, store it as a temp variable
-            if (self.objectInStomach != null)
-            {
-                tempObject = self.objectInStomach;
-            }
-            // Swap in queued object
-
-            //Logger.LogDebug($"Stored item: {itemDeliveryQueue.Peek().id}, {itemDeliveryQueue.Peek().type.value}");
-            self.objectInStomach = Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Dequeue(), self.room);
-            //Logger.LogDebug($"Converted object: {self.objectInStomach?.type}");
-
+            self.objectInStomach ??= Plugin.ItemToAbstractObject(Plugin.RandoManager.itemDeliveryQueue.Dequeue(), self.room);
             orig(self);
-
-            // If we stored an already swallowed object, put it back now
-            if (tempObject != null)
-            {
-                self.objectInStomach = tempObject;
-            }
         }
 
         /// <summary>

--- a/Menu/MenuExtension.cs
+++ b/Menu/MenuExtension.cs
@@ -301,9 +301,9 @@ namespace RainWorldRandomizer
     {
         public string signalText;
         public FSprite symbolSprite;
-        private Color baseColor;
-        private Color greyColor;
-        private float baseScale;
+        private readonly Color baseColor;
+        private readonly Color greyColor;
+        private readonly float baseScale;
 
         public BorderlessSymbolButton(Menu.Menu menu, MenuObject owner, string symbolName, string signalText, Vector2 pos) : base(menu, owner, pos, new(24f, 24f))
         {

--- a/Menu/MenuExtension.cs
+++ b/Menu/MenuExtension.cs
@@ -185,7 +185,7 @@ namespace RainWorldRandomizer
             };
             subObjects.Add(roundedRect);
 
-            menuLabels[0] = new MenuLabel(menu, this, "Currently Unlocked Gates:", new Vector2(10f, -13f), default, false, null);
+            menuLabels[0] = new MenuLabel(menu, this, "Currently Unlocked Gates:", new Vector2(10.01f, -13.01f), default, false, null);
             menuLabels[0].label.color = Menu.Menu.MenuRGB(Menu.Menu.MenuColors.White);
             menuLabels[0].label.alignment = FLabelAlignment.Left;
             subObjects.Add(menuLabels[0]);
@@ -194,7 +194,7 @@ namespace RainWorldRandomizer
             {
                 menuLabels[i] = new MenuLabel(menu, this,
                     Plugin.GateToString(openedGates[i - 1], Plugin.RandoManager.currentSlugcat),
-                    new Vector2(10f, -15f - (15f * i)), default, false, null);
+                    new Vector2(10.01f, -15.01f - (15f * i)), default, false, null);
                 menuLabels[i].label.color = Menu.Menu.MenuRGB(Menu.Menu.MenuColors.MediumGrey);
                 menuLabels[i].label.alignment = FLabelAlignment.Left;
                 subObjects.Add(menuLabels[i]);
@@ -228,7 +228,7 @@ namespace RainWorldRandomizer
             };
             subObjects.Add(roundedRect);
 
-            label = new MenuLabel(menu, this, "Pending items:", new Vector2(10f, -13f), default, false, null);
+            label = new MenuLabel(menu, this, "Pending items (Click to retrieve)", new Vector2(10.01f, -13.01f), default, false, null);
             label.label.color = Menu.Menu.MenuRGB(Menu.Menu.MenuColors.White);
             label.label.alignment = FLabelAlignment.Left;
             subObjects.Add(label);

--- a/RainWorldRandomizer.csproj
+++ b/RainWorldRandomizer.csproj
@@ -90,9 +90,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Unity.Mathematics">
-      <HintPath>bin\References\Unity.Mathematics.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>bin\References\UnityEngine.dll</HintPath>
     </Reference>

--- a/RainWorldRandomizer.csproj
+++ b/RainWorldRandomizer.csproj
@@ -90,6 +90,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Unity.Mathematics">
+      <HintPath>bin\References\Unity.Mathematics.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>bin\References\UnityEngine.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Can now click on items in the pending items display to spawn them in when unpausing. Items are placed in hand when possible, otherwise they are dropped on the ground.

Stomach delivery now occurs *after* any normally stored object is retrieved. 
Shelter delivery now only delivers up to 5 items at once, to avoid shelter cramming.

