### PR TITLE
Add Inv to standalone

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -13,6 +13,8 @@ namespace RainWorldRandomizer
         /// Describes which food quest items can be eaten by each slugcat. Matches order of <see cref="WinState.GourmandPassageTracker"/>
         /// </summary>
         public static readonly Dictionary<SlugcatStats.Name, bool[]> SlugcatFoodQuestAccessibility = [];
+
+        // -- Cheat sheet for food quest access definitions --
         // SlimeMold, DangleFruit, BatFly, Mushroom, BlackLizard, WaterNut, JellyFish, JetFish, GlowWeed, Salamander, Snail,
         // Hazer, EggBug, LillyPuck, YellowLizard, GrappleWorm, Neuron, Centiwing, DandelionPeach, CyanLizard, GooieDuck, RedCenti
 
@@ -175,17 +177,6 @@ namespace RainWorldRandomizer
                         false, false, false,
                         false, false, false, false, false, false, false,
                         false, false, false, false,
-                    ]},
-                    { MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel,
-                    [
-                        true, true, true, true, true, true, true, true, true, true, true,
-                        true, true, true, true, true, true, true, true, true, true, true,
-                        true, true, true, true,
-                        true, true, true, true, true, true, true, true,
-                        true, true, true,
-                        true, true, true,
-                        true, true, true, true, true, true, true,
-                        false, false, false, false,
                     ]}
                 });
 
@@ -195,8 +186,7 @@ namespace RainWorldRandomizer
                     { MoreSlugcatsEnums.SlugcatStatsName.Artificer, "GW_S09" },
                     { MoreSlugcatsEnums.SlugcatStatsName.Rivulet, "DS_S02l" },
                     { MoreSlugcatsEnums.SlugcatStatsName.Spear, "SU_S05" },
-                    { MoreSlugcatsEnums.SlugcatStatsName.Saint, "SI_S04" },
-                    { MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel, "SH_S09" },
+                    { MoreSlugcatsEnums.SlugcatStatsName.Saint, "SI_S04" }
                 });
             }
 

--- a/Generation/CustomLogicBuilder.cs
+++ b/Generation/CustomLogicBuilder.cs
@@ -237,7 +237,13 @@ namespace RainWorldRandomizer.Generation
 
         // ---- Define logic functions
 
-        public static void DefineLogicNoDLC()
+        public static void DefineLogic()
+        {
+            if (ModManager.MSC) DefineLogicMSC();
+            else DefineLogicNoDLC();
+        }
+
+        private static void DefineLogicNoDLC()
         {
             // Cannot climb SB Ravine
             AddSubregion(new SubregionBlueprint("SB", "SBRavine",
@@ -258,7 +264,7 @@ namespace RainWorldRandomizer.Generation
                 SlugcatStats.Name.White, SlugcatStats.Name.Yellow);
         }
 
-        public static void DefineLogicMSC()
+        private static void DefineLogicMSC()
         {
             // --- Locations ---
 
@@ -266,17 +272,11 @@ namespace RainWorldRandomizer.Generation
             AddLocationRule("Pearl-MS",
                 new RulePatch(new TimelineAccessRule(SlugcatStats.Timeline.Artificer, TimelineAccessRule.TimelineOperation.AtOrBefore)));
 
-            // Artificer and Inv can't reach underwater GW token
+            // Artificer can't reach underwater GW token
             AddLocationRule("Token-BrotherLongLegs",
                 new RulePatch(new(AccessRule.IMPOSSIBLE_ID)),
                 SelectionMethod.Whitelist,
-                MoreSlugcatsEnums.SlugcatStatsName.Artificer, MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
-
-            // Inv can't reach underwater GW token
-            AddLocationRule("Token-RedLizard",
-                new RulePatch(new(AccessRule.IMPOSSIBLE_ID)),
-                SelectionMethod.Whitelist,
-                MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+                MoreSlugcatsEnums.SlugcatStatsName.Artificer);
 
             // Waterfront Safari token is in a very silly location for Spearmaster
             AddLocationRule("Token-S-LM",
@@ -442,6 +442,8 @@ namespace RainWorldRandomizer.Generation
 
             // Any start in OE is instant ending access
             AddBlacklistedStart("OE");
+
+            InvCompat.DefineLogic();
         }
     }
 }

--- a/Generation/CustomLogicBuilder.cs
+++ b/Generation/CustomLogicBuilder.cs
@@ -204,7 +204,7 @@ namespace RainWorldRandomizer.Generation
         }
 
         /// <summary>
-        /// Competely remove a region from logic
+        /// Competely remove a region from logic. Happens before any subregions are created.
         /// </summary>
         /// <param name="regionID">ID of the affected region. Can be the region acronym for generated regions, 
         /// or the given ID of custom subregions</param>

--- a/Generation/InvCompat.cs
+++ b/Generation/InvCompat.cs
@@ -1,0 +1,68 @@
+﻿using MoreSlugcats;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static RainWorldRandomizer.Generation.CustomLogicBuilder;
+
+namespace RainWorldRandomizer.Generation
+{
+    /// <summary>
+    /// Test and demonstration for adding randomizer logic through another class or mod
+    /// </summary>
+    public static class InvCompat
+    {
+        /// <summary>
+        /// Call this after <see cref="Constants.InitializeConstants"/> and before <see cref="StaticWorld.InitStaticWorld"/>.
+        /// Easiest is just to do this in <see cref="RainWorld.PostModsInit"/>
+        /// </summary>
+        public static void Init()
+        {
+            // Most importantly, mark the slugcat as playable
+            Constants.CompatibleSlugcats.Add(MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+
+            // Add flags for what food quest foods are edible. You can read what foods these match to in the Constants class
+            Constants.SlugcatFoodQuestAccessibility[MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel] =
+            [
+                true, true, true, true, true, true, true, true, true, true, true,
+                true, true, true, true, true, true, true, true, true, true, true,
+                true, true, true, true,
+                true, true, true, true, true, true, true, true,
+                true, true, true,
+                true, true, true,
+                true, true, true, true, true, true, true,
+                false, false, false, false,
+            ];
+
+            // Define the default starting room and region, for when start is not randomized
+            Constants.SlugcatDefaultStartingDen[MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel] = "SH_S09";
+            Constants.SlugcatStartingRegion[MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel] = "SH";
+        }
+
+        /// <summary>
+        /// Call this in a hook to <see cref="CustomLogicBuilder.DefineLogic"/>
+        /// </summary>
+        public static void DefineLogic()
+        {
+            // Inv can't reach under-cheese GW tokens
+            AddLocationRule("Token-BrotherLongLegs",
+                new RulePatch(new(AccessRule.IMPOSSIBLE_ID)),
+                SelectionMethod.Whitelist,
+                MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+            AddLocationRule("Token-RedLizard",
+                new RulePatch(new(AccessRule.IMPOSSIBLE_ID)),
+                SelectionMethod.Whitelist,
+                MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+
+            // Travelling up the wall isn't in logic for Inv. Also covers the one-way path to Pebbles' access shaft
+            AddSubregion(new SubregionBlueprint("UWWall", "UWInvWall",
+                    ["Pearl-UW", "Echo-UW", "Shelter-UW_S03"],
+                    ["GATE_SS_UW", "GATE_UW_LC"],
+                    ["UW_S03"],
+                    (new(AccessRule.IMPOSSIBLE_ID), new())),
+                SelectionMethod.Whitelist,
+                MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+        }
+    }
+}

--- a/Generation/InvCompat.cs
+++ b/Generation/InvCompat.cs
@@ -63,6 +63,12 @@ namespace RainWorldRandomizer.Generation
                     (new(AccessRule.IMPOSSIBLE_ID), new())),
                 SelectionMethod.Whitelist,
                 MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
+
+            // Blacklist The Exterior altogether if allow setting not checked
+            AddBlacklistedRegion("UW",
+                new RulePatch(new OptionAccessRule("AllowExteriorForInv", true)),
+                SelectionMethod.Whitelist,
+                MoreSlugcatsEnums.SlugcatStatsName.Sofanthiel);
         }
     }
 }

--- a/Generation/State.cs
+++ b/Generation/State.cs
@@ -248,6 +248,8 @@ namespace RainWorldRandomizer.Generation
         /// <param name="region"></param>
         public void PurgeRegion(RandoRegion region)
         {
+            if (region is null) return;
+
             foreach (Connection con in region.connections.ToList())
             {
                 con.Destroy();

--- a/Generation/VanillaGenerator.cs
+++ b/Generation/VanillaGenerator.cs
@@ -140,8 +140,13 @@ namespace RainWorldRandomizer.Generation
             List<string> slugcatRegions = [.. SlugcatStats.SlugcatStoryRegions(slugcat), .. SlugcatStats.SlugcatOptionalRegions(slugcat)];
             // Add Metropolis to region list if option set
             if (ModManager.MSC && RandoOptions.ForceOpenMetropolis) slugcatRegions.Add("LC");
-            // Remove Submerged Superstructure from list if not desired
-            if (ModManager.MSC && !RandoOptions.ForceOpenSubmerged && slugcat != MoreSlugcatsEnums.SlugcatStatsName.Rivulet) slugcatRegions.Remove("MS");
+            // Remove regions from logic
+            foreach (var region in CustomLogicBuilder.GetLogicForSlugcat(slugcat).blacklistedRegions)
+            {
+                if (region.Value.rule?.IsPossible(state) is false or null) continue;
+                slugcatRegions.Remove(region.Key);
+                generationLog.AppendLine($"Removed region {region.Key}");
+            }
 
             foreach (string regionShort in Region.GetFullRegionOrder())
             {
@@ -616,7 +621,6 @@ namespace RainWorldRandomizer.Generation
                     generationLog.AppendLine($"Removed impossible location: {loc.ID}");
                 }
             }
-
 
             // Log all logic
             if (logVerbose)

--- a/Menu/OptionsMenu.cs
+++ b/Menu/OptionsMenu.cs
@@ -128,6 +128,10 @@ namespace RainWorldRandomizer
                 new ConfigurableInfo("Allows access to Submerged Superstructure as non-Rivulet slugcats (When possible)", null, "",
                     ["Open Submerged Superstructure"]));
 
+            RandoOptions.allowExteriorForInv = config.Bind<bool>("allowExteriorForInv", false, 
+                new ConfigurableInfo("By default when playing as Inv, The Exterior is removed from logic due to its excessive difficulty", null, "",
+                    ["Open Exterior for Inv"]));
+
             RandoOptions.useFoodQuestChecks = config.Bind<string>("useFoodQuestChecks", "Disabled",
                 new ConfigurableInfo("Makes every food in Gourmand's food quest count as a check. Other slugcats will only consider the foods they can eat", null, "",
                     ["Use Food quest checks"]));
@@ -350,6 +354,8 @@ namespace RainWorldRandomizer
             unlockRegionsGroup.AddCheckBox(RandoOptions.allowMetroForOthers, new(LEFT_OPTION_X, runningY));
             runningY -= NEWLINE_DECREMENT;
             unlockRegionsGroup.AddCheckBox(RandoOptions.allowSubmergedForOthers, new(LEFT_OPTION_X, runningY));
+            runningY -= NEWLINE_DECREMENT;
+            unlockRegionsGroup.AddCheckBox(RandoOptions.allowExteriorForInv, new(LEFT_OPTION_X, runningY));
             runningY -= NEWLINE_DECREMENT * 3.5f;
 
             // Check types

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -194,6 +194,7 @@ namespace RainWorldRandomizer
 
             Constants.InitializeConstants();
             CustomRegionCompatability.Init();
+            InvCompat.Init();
         }
 
         public void PostModsInit(On.RainWorld.orig_PostModsInit orig, RainWorld self)
@@ -223,12 +224,11 @@ namespace RainWorldRandomizer
         {
             orig();
             AccessRuleConstants.InitConstants();
-
             CustomLogicBuilder.ClearDefinedLogic();
+
             CustomLogicBuilder.InitNewSlugcats([.. Constants.CompatibleSlugcats]);
 
-            if (ModManager.MSC) CustomLogicBuilder.DefineLogicMSC();
-            else CustomLogicBuilder.DefineLogicNoDLC();
+            CustomLogicBuilder.DefineLogic();
         }
 
         public void LoadResources(On.RainWorld.orig_LoadModResources orig, RainWorld self)

--- a/RainWorldRandomizer.csproj
+++ b/RainWorldRandomizer.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Generation\Connection.cs" />
     <Compile Include="Generation\CustomLogicBuilder.cs" />
+    <Compile Include="Generation\InvCompat.cs" />
     <Compile Include="Generation\RandoRegion.cs" />
     <Compile Include="Hooks\FlowerCheckHandler.cs" />
     <Compile Include="Generation\AccessRule.cs" />

--- a/RandoOptions.cs
+++ b/RandoOptions.cs
@@ -35,6 +35,7 @@ namespace RainWorldRandomizer
         // MSC
         internal static Configurable<bool> allowMetroForOthers;
         internal static Configurable<bool> allowSubmergedForOthers;
+        internal static Configurable<bool> allowExteriorForInv;
         internal static Configurable<string> useFoodQuestChecks;
         internal static Configurable<bool> useExpandedFoodQuestChecks;
         internal static Configurable<bool> useEnergyCell;
@@ -108,6 +109,8 @@ namespace RainWorldRandomizer
 
         public static bool ForceOpenSubmerged => allowSubmergedForOthers.Value
             && Plugin.RandoManager is not ManagerArchipelago;
+
+        public static bool AllowExteriorForInv => allowExteriorForInv.Value;
 
         public static bool UseFoodQuest
         {


### PR DESCRIPTION
Can now start standalone randomizer games as Inv.

The logic code is applied in its own class, as a demonstration to anyone wishing to add logic for mods in the future.

A new option is present in the Remix menu, to allow access to The Exterior. By default, this is off and The Exterior (and subsequently Five Pebbles) are removed from logic altogether.

(Finally) closes #30.