### PR TITLE
Refactor Archipelago connection

### DIFF
--- a/Archipelago/ArchipelagoConnection.cs
+++ b/Archipelago/ArchipelagoConnection.cs
@@ -234,7 +234,11 @@ namespace RainWorldRandomizer
             CurrentlyConnecting = false;
             ReceivedSlotData = false;
 
-            if (resetManager) Plugin.RandoManager = null;
+            if (resetManager) 
+            { 
+                Plugin.RandoManager = null;
+                waitingItemPackets.Clear();
+            }
 
             return true;
         }

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -318,17 +318,22 @@ namespace RainWorldRandomizer
 
             locationsStatus[location] = true;
 
-            // We still gave the location, but we're offline so it can't be sent yet
-            if (!ArchipelagoConnection.SocketConnected)
-            {
-                Plugin.Log.LogInfo($"Found location while offline: {location}");
-                return true;
-            }
-
             if (!LocationToID.TryGetValue(location, out long locID))
             {
                 Plugin.Log.LogError($"Failed to find ID for location: {location}");
             }
+
+            // We still gave the location, but we're offline so it can't be sent yet
+            if (!ArchipelagoConnection.SocketConnected)
+            {
+                Plugin.Log.LogInfo($"Found location while offline: {location}");
+                string logName = ArchipelagoConnection.Session?.Locations.GetLocationNameFromId(locID) ?? location;
+                Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText(
+                    $"{logName} was found but not sent, as client is disconnected. Reconnect to send found locations.",
+                    UnityEngine.Color.yellow));
+                return true;
+            }
+
             ArchipelagoConnection.Session.Locations.CompleteLocationChecks(locID);
             Plugin.Log.LogInfo($"Found location: {location}!");
 

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -176,7 +176,6 @@ namespace RainWorldRandomizer
             }
             else if (itemPacket.Index > ArchipelagoConnection.lastItemIndex)
             {
-                // Much more common, this will hit if item packets are lost in transit
                 Plugin.Log.LogWarning($"New item index is greater than last index. Missed an item?");
                 return;
             }
@@ -201,8 +200,6 @@ namespace RainWorldRandomizer
         /// <param name="isNew">If false, if the item is a consumable it will be ignored</param>
         public void AquireItem(string item, bool isNew)
         {
-            Plugin.Log.LogDebug($"Get item {item}. isNew is {isNew}");
-
             if (item.StartsWith("GATE_"))
             {
                 if (!gatesStatus.ContainsKey(item))

--- a/Archipelago/ManagerArchipelago.cs
+++ b/Archipelago/ManagerArchipelago.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,22 +12,18 @@ namespace RainWorldRandomizer
         public bool locationsLoaded = false;
         public bool gameCompleted = false;
 
-        public static Dictionary<string, string> NameToAPLocation = [];
-        public static Dictionary<string, string> APLocationToName = [];
-        public static Dictionary<string, string> NameToAPItem = [];
-        public static Dictionary<string, string> APItemToName = [];
-        internal Dictionary<string, bool> locationsStatus = [];
+        // Mapping AP item names to the string IDs the mod uses for items
+        public static Dictionary<string, string> ClientNameToAPItem = [];
+        public static Dictionary<string, string> APItemToClientName = [];
+        // Mapping numerical AP location IDs to the string IDs the mod uses for locations
+        public static Dictionary<string, long> LocationToID = [];
+        public static Dictionary<long, string> IDToLocation = [];
 
-        public void Init()
-        {
-            if (NameToAPLocation.Count == 0) LoadAPLocationDicts();
-        }
+        internal Dictionary<string, bool> locationsStatus = [];
 
         public override void StartNewGameSession(SlugcatStats.Name storyGameCharacter, bool continueSaved)
         {
-            isNewGame = !continueSaved;
-
-            if (!(ArchipelagoConnection.Session?.Socket.Connected ?? false))
+            if (!ArchipelagoConnection.SocketConnected)
             {
                 Plugin.Log.LogError("Tried to start AP campaign without first connecting to server");
                 isRandomizerActive = false;
@@ -34,6 +31,7 @@ namespace RainWorldRandomizer
             }
 
             base.StartNewGameSession(storyGameCharacter, continueSaved);
+            LoadAPLocationDicts();
 
             // Verify slugcat
             if (storyGameCharacter != ArchipelagoConnection.Slugcat)
@@ -45,6 +43,17 @@ namespace RainWorldRandomizer
                 Plugin.Singleton.notifQueue.Enqueue(new ChatLog.MessageText("Archipelago failed to start: Selected campaign does not match archipelago options.", UnityEngine.Color.red));
                 return;
             }
+
+            // Load save file
+            string saveId = $"{ArchipelagoConnection.generationSeed}_{ArchipelagoConnection.playerName}";
+            try
+            {
+                // TODO: There should be some validation that the save game being loaded is the correct one for the AP slot
+                // Probably do this when integrating data into save file. Then we can mine save data to find if player is loading the correct save
+                if (SaveManager.IsThereAnAPSave(saveId)) LoadSave(saveId);
+                else CreateNewSave(saveId);
+            }
+            catch (Exception e) { Plugin.Log.LogError(e); }
 
             // Attempt initialization
             if (!InitializeSession(storyGameCharacter))
@@ -59,9 +68,11 @@ namespace RainWorldRandomizer
             // All good, randomizer active
         }
 
-        public void Reset()
+        /// <summary>
+        /// Soft reset, clears all items in preperation for a new inventory
+        /// </summary>
+        public void RemoveAllItems()
         {
-            // Reset all tracking variables
             _currentMaxKarma = 0;
             _hunterBonusCyclesGiven = 0;
             _givenNeuronGlow = false;
@@ -69,19 +80,12 @@ namespace RainWorldRandomizer
             _givenRobo = false;
             _givenPebblesOff = false;
             _givenSpearPearlRewrite = false;
-            customStartDen = "";
-            gameCompleted = false;
-            locationsLoaded = false;
 
-            // Reset unlock lists
             gatesStatus.Clear();
             passageTokensStatus.Clear();
             itemDeliveryQueue.Clear();
             lastItemDeliveryQueue.Clear();
             pendingTrapQueue.Clear();
-
-            // Clear notifications
-            Plugin.Singleton.notifQueue.Clear();
         }
 
         public void LoadSave(string saveId)
@@ -94,8 +98,9 @@ namespace RainWorldRandomizer
             // Set locations the server says we found
             foreach (long locID in ArchipelagoConnection.Session.Locations.AllLocationsChecked)
             {
-                string loc = GetLocStringIDFromID(locID);
-                if (locationsStatus.TryGetValue(loc, out bool found) && !found)
+                if (IDToLocation.TryGetValue(locID, out string loc)
+                    && locationsStatus.TryGetValue(loc, out bool found)
+                    && !found)
                 {
                     locationsStatus[loc] = true;
                 }
@@ -105,8 +110,9 @@ namespace RainWorldRandomizer
             List<long> offlineLocs = [];
             foreach (long locID in ArchipelagoConnection.Session.Locations.AllMissingLocations)
             {
-                string loc = GetLocStringIDFromID(locID);
-                if (locationsStatus.TryGetValue(loc, out bool found) && found)
+                if (IDToLocation.TryGetValue(locID, out string loc)
+                    && locationsStatus.TryGetValue(loc, out bool found)
+                    && found)
                 {
                     offlineLocs.Add(locID);
                 }
@@ -127,50 +133,75 @@ namespace RainWorldRandomizer
 
         public void CreateNewSave(string saveId)
         {
-            isNewGame = true;
             currentSlugcat = ArchipelagoConnection.Slugcat;
 
             locationsStatus.Clear();
-            foreach (long loc in ArchipelagoConnection.Session.Locations.AllLocations)
+            foreach (long locID in ArchipelagoConnection.Session.Locations.AllLocations)
             {
-                if (GetLocStringIDFromID(loc) is null)
+                if (!IDToLocation.TryGetValue(locID, out string loc))
                 {
-                    Plugin.Log.LogError($"Location {loc} does not exist in DataPackage");
+                    Plugin.Log.LogError($"Location {locID} does not exist in DataPackage");
                     continue;
                 }
-                locationsStatus.Add(GetLocStringIDFromID(loc), false);
+                locationsStatus.Add(loc, false);
             }
             Plugin.Log.LogInfo($"Found no saved game, creating new save");
-            //SaveManager.WriteAPSaveToFile(saveId, ArchipelagoConnection.lastItemIndex, locationsStatus);
 
             locationsLoaded = true;
-
             SaveGame(false);
         }
 
-        public void InitNewInventory(List<string> newItems)
+        public void TryAquireNextItemPacket()
         {
-            _currentMaxKarma = 0;
-            _hunterBonusCyclesGiven = 0;
-            _givenNeuronGlow = false;
-            _givenMark = false;
-            _givenRobo = false;
-            _givenPebblesOff = false;
-            _givenSpearPearlRewrite = false;
+            if (ArchipelagoConnection.waitingItemPackets.Count == 0) return;
 
-            foreach (string item in newItems)
+            Archipelago.MultiClient.Net.Packets.ReceivedItemsPacket itemPacket = ArchipelagoConnection.waitingItemPackets.Dequeue();
+
+            Plugin.Log.LogInfo($"Received items packet. Index: {itemPacket.Index} | Last index: {ArchipelagoConnection.lastItemIndex} | Item count: {itemPacket.Items.Length}");
+
+            bool isNewInventory = false;
+            if (itemPacket.Index == 0)
             {
-                AquireItem(item, false, false);
+                RemoveAllItems();
+                isNewInventory = true;
             }
+            // Multiclient sends Sync packet for us, the new inventory should arrive soon
+            else if (itemPacket.Index < ArchipelagoConnection.lastItemIndex)
+            {
+                // Could happen if host save file was reverted to a previous state.
+                // If that happens, "new" consumable items that are before our last stored ID would be lost.
+                // This is an edge case though, and there are no progression consumables so it isn't worth the effort to fix.
+                Plugin.Log.LogWarning($"New item index is lower than last index. Server is confused?");
+                return;
+            }
+            else if (itemPacket.Index > ArchipelagoConnection.lastItemIndex)
+            {
+                // Much more common, this will hit if item packets are lost in transit
+                Plugin.Log.LogWarning($"New item index is greater than last index. Missed an item?");
+                return;
+            }
+
+            for (int i = 0; i < itemPacket.Items.Length; i++)
+            {
+                string APItemName = ArchipelagoConnection.Session.Items.GetItemName(itemPacket.Items[i].Item);
+                // Even if item has no client map, try to give it anyway, maybe it works
+                if (!APItemToClientName.TryGetValue(APItemName, out string clientName)) Plugin.Log.LogError($"Could not find client name mapping for AP item: {APItemName}");
+
+                // If item packet index is 0, items before our stored last index are not new
+                AquireItem(clientName, !isNewInventory || i >= ArchipelagoConnection.lastItemIndex);
+            }
+
+            ArchipelagoConnection.lastItemIndex = itemPacket.Index + itemPacket.Items.Length;
         }
 
-        public void AquireItem(string item, bool printLog = true, bool isNew = true)
+        /// <summary>
+        /// Takes in a client item name and awards it to the player.
+        /// </summary>
+        /// <param name="item">Client name of item</param>
+        /// <param name="isNew">If false, if the item is a consumable it will be ignored</param>
+        public void AquireItem(string item, bool isNew)
         {
-            // If this doesn't pass it will just try to parse the AP name
-            if (APItemToName.ContainsKey(item))
-            {
-                item = APItemToName[item];
-            }
+            Plugin.Log.LogDebug($"Get item {item}. isNew is {isNew}");
 
             if (item.StartsWith("GATE_"))
             {
@@ -288,18 +319,17 @@ namespace RainWorldRandomizer
             locationsStatus[location] = true;
 
             // We still gave the location, but we're offline so it can't be sent yet
-            if (ArchipelagoConnection.Session?.Socket.Connected is null or false)
+            if (!ArchipelagoConnection.SocketConnected)
             {
                 Plugin.Log.LogInfo($"Found location while offline: {location}");
                 return true;
             }
 
-            long locId = GetIDFromLocStringID(location);
-            if (locId == -1L)
+            if (!LocationToID.TryGetValue(location, out long locID))
             {
                 Plugin.Log.LogError($"Failed to find ID for location: {location}");
             }
-            ArchipelagoConnection.Session.Locations.CompleteLocationChecks(locId);
+            ArchipelagoConnection.Session.Locations.CompleteLocationChecks(locID);
             Plugin.Log.LogInfo($"Found location: {location}!");
 
             return true;
@@ -339,8 +369,9 @@ namespace RainWorldRandomizer
             {
                 foreach (long locID in ArchipelagoConnection.Session.Locations.AllLocationsChecked)
                 {
-                    string loc = GetLocStringIDFromID(locID);
-                    if (locationsStatus.TryGetValue(loc, out bool found) && !found)
+                    if (IDToLocation.TryGetValue(locID, out string loc)
+                        && locationsStatus.TryGetValue(loc, out bool found)
+                        && !found)
                     {
                         locationsStatus[loc] = true;
                     }
@@ -359,7 +390,7 @@ namespace RainWorldRandomizer
             public Dictionary<string, string> items = items;
         }
 
-        private static void LoadAPLocationDicts()
+        public static void LoadAPLocationDicts()
         {
             string path = Path.Combine(ModManager.ActiveMods.First(m => m.id == Plugin.PLUGIN_GUID).NewestPath, $"ap_names_map.json");
 
@@ -369,45 +400,22 @@ namespace RainWorldRandomizer
                 return;
             }
 
+            IDToLocation.Clear();
+            LocationToID.Clear();
+            ClientNameToAPItem.Clear();
+            APItemToClientName.Clear();
+
             APReadableNames names = JsonConvert.DeserializeObject<APReadableNames>(File.ReadAllText(path));
 
-            NameToAPLocation = names.locations;
-            NameToAPItem = names.items;
+            // Create alternate datapackage with client names
+            IDToLocation = names.locations.Keys.ToDictionary((clientName)
+                => ArchipelagoConnection.Session.Locations.GetLocationIdFromName(ArchipelagoConnection.GAME_NAME, names.locations[clientName]));
+            foreach (var kvp in IDToLocation) LocationToID.Add(kvp.Value, kvp.Key);
 
-            foreach (var keyVal in NameToAPLocation)
-            {
-                //Plugin.Log.LogDebug($"{keyVal.Key} | {keyVal.Value}");
-                APLocationToName.Add(keyVal.Value, keyVal.Key);
-            }
-            foreach (var keyVal in NameToAPItem)
-            {
-                //Plugin.Log.LogDebug($"{keyVal.Key} | {keyVal.Value}");
-                APItemToName.Add(keyVal.Value, keyVal.Key);
-            }
-        }
-
-        public static string GetLocStringIDFromID(long locID)
-        {
-            if (APLocationToName.TryGetValue(ArchipelagoConnection.Session.Locations.GetLocationNameFromId(locID), out string stringID))
-            {
-                return stringID;
-            }
-            else
-            {
-                return ArchipelagoConnection.Session.Locations.GetLocationNameFromId(locID);
-            }
-        }
-
-        public long GetIDFromLocStringID(string stringID)
-        {
-            if (NameToAPLocation.TryGetValue(stringID, out string loc))
-            {
-                return ArchipelagoConnection.Session.Locations.GetLocationIdFromName(ArchipelagoConnection.GAME_NAME, loc);
-            }
-            else
-            {
-                return ArchipelagoConnection.Session.Locations.GetLocationIdFromName(ArchipelagoConnection.GAME_NAME, stringID);
-            }
+            // Create translation from AP item names to client ones.
+            // Would prefer to map to the numerical AP item IDs, but MultiClient doesn't provide an easy way to convert item names to ID
+            ClientNameToAPItem = names.items;
+            foreach (var kvp in ClientNameToAPItem) APItemToClientName.Add(kvp.Value, kvp.Key);
         }
     }
 }

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -80,6 +80,9 @@ namespace RainWorldRandomizer
                     {
                         Plugin.RandoManager.StartNewGameSession(self.rainWorld.progression.miscProgressionData.currentlySelectedSinglePlayerSlugcat,
                             self.menuSetup.startGameCondition != ProcessManager.MenuSetup.StoryGameInitCondition.New);
+
+                        // Have AP manager grab the first item packet (the one with the full inventory) right away
+                        if (Plugin.RandoManager is ManagerArchipelago managerAP) managerAP.TryAquireNextItemPacket();
                     }
                     catch (Exception e)
                     {

--- a/Hooks/GameLoopHooks.cs
+++ b/Hooks/GameLoopHooks.cs
@@ -61,7 +61,10 @@ namespace RainWorldRandomizer
             if (ID == ProcessManager.ProcessID.Game
                 && (Plugin.RandoManager is null || !Plugin.RandoManager.isRandomizerActive))
             {
-                // If we don't have a manager yet, create one
+                // If AP is connected, use AP manager
+                if (ArchipelagoConnection.SocketConnected) Plugin.RandoManager = new ManagerArchipelago();
+
+                // Default to vanilla manager
                 Plugin.RandoManager ??= new ManagerVanilla();
 
                 if (self.rainWorld.progression.miscProgressionData.currentlySelectedSinglePlayerSlugcat is null)
@@ -291,6 +294,9 @@ namespace RainWorldRandomizer
 
             // Active only
             if (!Plugin.RandoManager.isRandomizerActive) return;
+
+            // Read and apply a single queued item packet every frame
+            if (Plugin.RandoManager is ManagerArchipelago APManager) APManager.TryAquireNextItemPacket();
 
             // Applying glow effect if unlock has been given
             for (int i = 0; i < self.Players.Count; i++)

--- a/Hooks/MiscHooks.cs
+++ b/Hooks/MiscHooks.cs
@@ -4,7 +4,6 @@ using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
 using MoreSlugcats;
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using UnityEngine;
@@ -182,7 +181,7 @@ namespace RainWorldRandomizer
             ILCursor c1 = new(il);
 
             // Check slugcat unlocked at 0362
-            c1.GotoNext(MoveType.After, 
+            c1.GotoNext(MoveType.After,
                 x => x.MatchCallOrCallvirt(typeof(SlugcatSelectMenu).GetMethod(nameof(SlugcatSelectMenu.SlugcatUnlocked)))
                 );
             c1.Emit(OpCodes.Ldarg_0);
@@ -192,9 +191,8 @@ namespace RainWorldRandomizer
             {
                 if (!RandoOptions.archipelago.Value) return orig;
 
-                return Plugin.RandoManager is ManagerArchipelago manager
-                    && manager.locationsLoaded
-                    && manager.currentSlugcat == self.colorFromIndex(self.slugcatPageIndex);
+                return ArchipelagoConnection.SocketConnected
+                    && ArchipelagoConnection.Slugcat == self.colorFromIndex(self.slugcatPageIndex);
             }
         }
 


### PR DESCRIPTION
The way the Archipelago connection handles receiving items has been changed to queue item packets to be collected in sequence in the game loop. 

This accomplishes multiple things:
- `ManagerArchipelago` can now be handled similarly to `ManagerVanilla` in terms of life cycle. They should both only exist while the player is playing a campaign save file.
- Potentially fixes a rumored issue with handling item packets off the main thread
- Simplifies item handling for readability
- No longer have to await connection handshake completing before taking in item packets

Other things also done here:
- Connection is closed properly before application exit (when done naturally from the main menu button)
- Client name mapping is stored and read differently. Maps location client names directly to the numerical IDs rather than having to convert from AP ID => AP name => client name every time.
- Messages are now sent to offline players on location collect to remind them that they are offline
